### PR TITLE
Add support for D3.js v5 and C3.js ^0.6.0

### DIFF
--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -15,7 +15,7 @@ d3:
   remote: https://github.com/d3/d3
   version: "3.5.17"
   license:
-    name: MIT
+    name: BSD-3
     url: https://github.com/d3/d3/blob/master/LICENSE
     gpl-compatible: true
   js:

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -6,10 +6,10 @@ c3:
     url: https://github.com/c3js/c3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.12/c3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.2/c3.min.js: { type: external, minified: true }
   css:
     component:
-      https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.12/c3.min.css: { type: external, minified: true }
+      https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.2/c3.min.css: { type: external, minified: true }
 
 d3:
   remote: https://github.com/d3/d3
@@ -19,7 +19,7 @@ d3:
     url: https://github.com/d3/d3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js: { type: external, minified: true }
+    https://unpkg.com/d3@5.5.0/dist/d3.min.js: { type: external, minified: true }
 
 datatables:
   remote: https://github.com/DataTables/DataTables

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -19,7 +19,7 @@ d3:
     url: https://github.com/d3/d3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://unpkg.com/d3@5.5.0/dist/d3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/d3/5.5.0/d3.min.js: { type: external, minified: true }
 
 datatables:
   remote: https://github.com/DataTables/DataTables

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -88,6 +88,10 @@
         data.order = this.options.chart.data.order;
       }
 
+      if (this.options.chart.data.names) {
+        data.names = this.options.chart.data.names;
+      }
+
       this.config.data = data;
 
       return this;

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -738,6 +738,11 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       $settings['chart']['data']['columns'][] = array_merge([$field], $this->getSourceFieldValues($field));
     }
 
+    // Override fields labels if set in chart options.
+    if (!empty($this->configuration['data']['field_labels'])) {
+      $settings['chart']['data']['names'] = $this->fieldLabels();
+    }
+
     return $settings;
   }
 

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -739,9 +739,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     }
 
     // Override fields labels if set in chart options.
-    if (!empty($this->configuration['data']['field_labels'])) {
-      $settings['chart']['data']['names'] = $this->fieldLabels();
-    }
+    $settings['chart']['data']['names'] = $this->fieldLabels();
 
     return $settings;
   }


### PR DESCRIPTION
- Libraries now use up to date versions of C3 and D3
- Chart labels now override correctly.