### PR TITLE
[GOVCMSD8-570] Replace deprecated methods with those compatible with …

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,0 +1,112 @@
+services:
+  php:
+    # Use PHP 7.2 with Apache to serve the Drupal site
+    image: tugboatqa/php:7.3-apache
+
+    # Set this as the default service. This does a few things
+    #   1. Clones the git repository into the service container
+    #   2. Exposes port 80 to the Tugboat HTTP proxy
+    #   3. Routes requests to the preview URL to this service
+    default: true
+
+    # Wait until the mysql service is done building
+    depends: mysql
+
+    visualdiffs:
+      :default:
+        - /
+        - /test
+        - /blog/example
+        - /events
+        - /themes/custom/govcms8_uikit_starter/styleguide/section-ui-kit.html
+
+    # A set of commands to run while building this service
+    commands:
+      # Commands that set up the basic preview infrastructure
+      init:
+        - printenv
+        - apt-get update
+        # Install bz2 and zip extensions
+        - apt-get install -y libbz2-dev libzip-dev
+        - docker-php-ext-install opcache bz2 zip
+        # Enable headers
+        - a2enmod headers rewrite
+
+        # Install node10/npm to build source
+        - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+        - apt-get install -y nodejs
+
+#       # Install drush-launcher
+        - wget -O /usr/local/bin/drush
+          https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+        - chmod +x /usr/local/bin/drush
+
+        # Install a vanilla govcms-project site under /var/govcms and link it to DOCROOT.
+        - rm -Rf /var/govcms
+        - COMPOSER_MEMORY_LIMIT=-1 composer create-project govcms/govcms8-project --stability dev --no-interaction --verbose /var/govcms
+        - ln -snf "/var/govcms/docroot" "${DOCROOT}"
+
+        # Prepare for install.
+        - cp "${TUGBOAT_ROOT}/.tugboat/settings.php" /var/govcms/docroot/sites/default/
+        - mkdir -p "/var/govcms/docroot/sites/default/files"
+        - chgrp -R www-data "/var/govcms/docroot/sites/default/files"
+        - find "/var/govcms/docroot/sites/default/files" -type d -exec chmod 2775 {} \;
+        - find "/var/govcms/docroot/sites/default/files" -type f -exec chmod 0664 {} \;
+
+        # Install the site.
+        - rm -rf /var/govcms/docroot/profiles/govcms/config/sync # In some cases the sync directory is created and a re-install fails.
+        - cd /var/govcms && drush -r "${DOCROOT}" site:install govcms install_configure_form.update_status_module='array(FALSE,FALSE)' -y
+        - cd /var/govcms && drush -r "${DOCROOT}" pm:enable govcms8_default_content -y
+      
+        # Cuts down on image size, although makes initial preview loading slower.
+        - cd /var/govcms && drush -r "${DOCROOT}" cr -y
+
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        # We have no external assets to update for testing the distro.
+
+      build:
+        # Add a "tugboat-latest" branch we can reference via composer in our /var/govcms/ project.
+        - cd "${TUGBOAT_ROOT}"
+        - git branch -D tugboat-latest || true
+        - git checkout -b tugboat-latest
+
+        # Tell the GovCMS project to use this "tugboat-latest" tag above to require dvf in this site.
+        - composer --working-dir=/var/govcms config repositories.local path "${TUGBOAT_ROOT}"
+        - composer --profile --working-dir=/var/govcms require drupal/dvf:dev-tugboat-latest drupal/ckan_connect
+        - cd /var/govcms && drush -r "${DOCROOT}" pm:enable dvf -y
+        
+        - drush -r "${DOCROOT}" cache-rebuild
+        - drush -r "${DOCROOT}" updb -y
+
+        - drush -r "${DOCROOT}" pml --filter=dvf
+        - composer --working-dir=/var/govcms show
+
+      visualdiffs:
+        - /
+        - /test
+        - /blog/example
+        - /events
+
+  # What to call the service hosting MySQL. This name also acts as the
+  # hostname to access the service by from the php service.
+  mysql:
+    # Use the latest available 5.x version of MySQL
+    image: tugboatqa/mysql:5
+
+    # A set of commands to run while building this service
+    commands:
+      # Commands that import files, databases,  or other assets. When an
+      # existing preview is refreshed, the build workflow starts here,
+      # skipping the init step, because the results of that step will
+      # already be present.
+      update:
+        # Copy a database dump from an external server. The public
+        # SSH key found in the Tugboat Repository configuration must be
+        # copied to the external server in order to use scp.
+        # - scp user@example.com:database.sql.gz /tmp/database.sql.gz
+        # - zcat /tmp/database.sql.gz | mysql tugboat
+        # - rm /tmp/database.sql.gz

--- a/.tugboat/settings.php
+++ b/.tugboat/settings.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * GovCMS Drupal settings for Tugboat only.
+ *
+ * Most settings based on Drupal defaults.
+ * Comments removed for brevity.
+ * @see https://git.drupalcode.org/project/drupal/blob/8.8.x/sites/default/default.settings.php
+ */
+$databases = [];
+$config_directories = array(
+  CONFIG_SYNC_DIRECTORY => 'sites/default/files/sync',
+);
+$settings['hash_salt'] = 'djfu983roawei90tk3;mva9023i9523';
+$settings['update_free_access'] = FALSE;
+$settings['file_scan_ignore_directories'] = [
+  'node_modules',
+  'bower_components',
+];
+$settings['entity_update_batch_size'] = 50;
+$databases['default']['default'] = array (
+  'database' => 'tugboat',
+  'username' => 'tugboat',
+  'password' => 'tugboat',
+  'prefix' => '',
+  'host' => 'mysql',
+  'port' => '3306',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+);
+if (PHP_SAPI === 'cli') {
+  ini_set('memory_limit', '256M');
+}
+$settings['trusted_host_patterns'] = ['.*'];
+$config['system.logging']['error_level'] = 'verbose';
+error_reporting(E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR);
+ini_set('display_errors', TRUE);
+ini_set('display_startup_errors', TRUE);

--- a/README.md
+++ b/README.md
@@ -55,9 +55,31 @@ this field type, see related modules above for modules currently available.
 
 * Create/edit an entity that contains the field you created above.
 * If using `Visualisation URL`, provide a URL to the remote data source
-* If using `Visualisation File`, upload a file containg the data (eg. CSV)
+* If using `Visualisation File`, upload a file containing the data (eg. CSV)
 * Open `Settings` to configure the visualisation style and the options
   available for that style. Eg. Graph type, axis settings, etc.
+
+## For developers: available hooks
+
+```php
+hook_dvf_source_configuration_alter();
+hook_dvf_visualisation_data_alter();
+hook_dvf_visualisation_build_alter();
+hook_dvf_style_configuration_alter();
+theme_dvf_style_configuration_alter();
+
+Example code:
+
+/**
+ * Implements theme_dvf_style_configuration_alter(). 
+ *
+ * Set a custom colour palette for all charts in a custom theme.
+ */
+function mytheme_dvf_style_configuration_alter(array &$configuration, VisualisationInterface $visualisation) {
+  $configuration['chart']['palette'] = '#000000,#aec7e8,#ff0000,#ffbb78,#fff000';
+  return $configuration;
+}
+```
 
 ## Development 
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
     "require": {
-        "flow/jsonpath": "^0.4.0",
+        "flow/jsonpath": "^0.4.0"
     }
 }

--- a/dvf.info.yml
+++ b/dvf.info.yml
@@ -2,5 +2,4 @@ name: Data Visualisation Framework
 description: 'Data Visualisation Framework makes it easy to generate visualisations from different data sources.'
 type: module
 package: Data Visualisation Framework
-core: 8.x
 core_version_requirement: ^8 || ^9

--- a/dvf.info.yml
+++ b/dvf.info.yml
@@ -3,3 +3,4 @@ description: 'Data Visualisation Framework makes it easy to generate visualisati
 type: module
 package: Data Visualisation Framework
 core: 8.x
+core_version_requirement: ^8 || ^9

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -79,3 +79,11 @@ jquery.dvfTables:
     - core/drupal
     - core/drupalSettings
     - dvf/datatables
+
+dvfAdmin:
+  version: "1.0.0"
+  js:
+    js/dvfAdmin.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -1,19 +1,19 @@
 c3:
   remote: https://github.com/c3js/c3
-  version: "0.4.12"
+  version: "0.7.1"
   license:
     name: MIT
     url: https://github.com/c3js/c3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.2/c3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.js: { type: external, minified: true }
   css:
     component:
-      https://cdnjs.cloudflare.com/ajax/libs/c3/0.6.2/c3.min.css: { type: external, minified: true }
+      https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.css: { type: external, minified: true }
 
 d3:
   remote: https://github.com/d3/d3
-  version: "3.5.17"
+  version: "5.5.0"
   license:
     name: BSD-3
     url: https://github.com/d3/d3/blob/master/LICENSE

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -34,9 +34,19 @@ datatables:
     component:
       https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.15/css/jquery.dataTables.css: { type: external, minified: true }
 
+filesaver:
+  remote: https://github.com/eligrey/FileSaver.js
+  version: "1.3.8"
+  license:
+    name: MIT
+    url: https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+  js:
+    https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js: { type: external, minified: true }
+
 jquery.dvfCharts:
   version: "1.0.0"
   js:
+    js/jquery.chart_export.js: {}
     js/jquery.dvfCharts.js: {}
   dependencies:
     - core/jquery
@@ -44,6 +54,7 @@ jquery.dvfCharts:
     - core/drupalSettings
     - dvf/d3
     - dvf/c3
+    - dvf/filesaver
 
 dvfCharts:
   version: "1.0.0"

--- a/dvf.module
+++ b/dvf.module
@@ -17,3 +17,16 @@ function dvf_help($route_name, RouteMatchInterface $route_match) {
       return $output;
   }
 }
+
+/**
+ * Implements hook_theme().
+ */
+function dvf_theme($existing, $type, $theme, $path) {
+  return [
+    'help_page' => [
+      'variables' => [
+        'topic' => '',
+      ],
+    ],
+  ];
+}

--- a/dvf.routing.yml
+++ b/dvf.routing.yml
@@ -1,0 +1,8 @@
+
+dvf.dvf_help_controller_help:
+  path: '/dvf/help/{topic}'
+  defaults:
+    _controller: '\Drupal\dvf\Controller\DvfHelpController::helpPage'
+    _title_callback: '\Drupal\dvf\Controller\DvfHelpController::getHelpPageTitle'
+  requirements:
+    _permission: 'administer site configuration'

--- a/dvf.routing.yml
+++ b/dvf.routing.yml
@@ -5,4 +5,4 @@ dvf.dvf_help_controller_help:
     _controller: '\Drupal\dvf\Controller\DvfHelpController::helpPage'
     _title_callback: '\Drupal\dvf\Controller\DvfHelpController::getHelpPageTitle'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'access content overview'

--- a/dvf.services.yml
+++ b/dvf.services.yml
@@ -8,3 +8,6 @@ services:
   plugin.manager.visualisation.style:
     class: Drupal\dvf\Plugin\VisualisationStyleManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']
+  dvf.helpers:
+    class: Drupal\dvf\DvfHelpers
+    arguments: []

--- a/dvf_ckan/dvf_ckan.info.yml
+++ b/dvf_ckan/dvf_ckan.info.yml
@@ -2,7 +2,7 @@ name: CKAN Data Visualisation
 description: 'CKAN integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - ckan_connect:ckan_connect
   - dvf:dvf

--- a/dvf_ckan/src/Plugin/Visualisation/Source/CkanResource.php
+++ b/dvf_ckan/src/Plugin/Visualisation/Source/CkanResource.php
@@ -88,6 +88,8 @@ class CkanResource extends VisualisationSourceBase implements ContainerFactoryPl
    *   The CKAN client.
    * @param \Drupal\ckan_connect\Parser\CkanResourceUrlParserInterface $ckan_resource_url_parser
    *   The CKAN resource URL parser.
+   * @param \Drupal\dvf\DvfHelpers $dvf_helpers
+   *   The DVF helpers.
    */
   public function __construct(
     array $configuration,

--- a/dvf_ckan/src/Plugin/Visualisation/Source/CkanResource.php
+++ b/dvf_ckan/src/Plugin/Visualisation/Source/CkanResource.php
@@ -130,7 +130,7 @@ class CkanResource extends VisualisationSourceBase implements ContainerFactoryPl
     }
     else {
       $raw_fields = $this->fetchFields();
-      $this->cache->set($cache_key, $raw_fields);
+      $this->cache->set($cache_key, $raw_fields, $this->getCacheExpiry());
     }
 
     $fields = [];
@@ -177,7 +177,7 @@ class CkanResource extends VisualisationSourceBase implements ContainerFactoryPl
     }
     else {
       $raw_records = $this->fetchRecords();
-      $this->cache->set($cache_key, $raw_records);
+      $this->cache->set($cache_key, $raw_records, $this->getCacheExpiry());
     }
 
     $records = [];

--- a/dvf_csv/dvf_csv.info.yml
+++ b/dvf_csv/dvf_csv.info.yml
@@ -2,6 +2,6 @@ name: CSV Data Visualisation
 description: 'CSV integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - dvf:dvf

--- a/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
+++ b/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
@@ -224,7 +224,7 @@ class CsvFile extends VisualisationSourceBase implements ContainerFactoryPluginI
     }
     else {
       $data = $this->fetchData();
-      $this->cache->set($cache_key, $data);
+      $this->cache->set($cache_key, $data, $this->getCacheExpiry());
     }
 
     return $data;

--- a/dvf_json/dvf_json.info.yml
+++ b/dvf_json/dvf_json.info.yml
@@ -2,6 +2,6 @@ name: JSON Data Visualisation
 description: 'JSON integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
-core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - dvf:dvf

--- a/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
+++ b/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
@@ -6,7 +6,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Url;
 use Drupal\dvf\Plugin\VisualisationInterface;
 use Drupal\dvf\Plugin\Visualisation\Source\VisualisationSourceBase;
 use Flow\JSONPath\JSONPath;
@@ -197,7 +196,7 @@ class JsonFile extends VisualisationSourceBase implements ContainerFactoryPlugin
     }
     else {
       $data = $this->fetchData();
-      $this->cache->set($cache_key, $data);
+      $this->cache->set($cache_key, $data, $this->getCacheExpiry());
     }
 
     return json_decode($data, TRUE);

--- a/js/dvfAdmin.js
+++ b/js/dvfAdmin.js
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * JavaScript behaviors for DVF admin forms.
+ */
+
+(function ($, Drupal) {
+
+  'use strict';
+
+  /**
+   * Provides the help information in a window popup.
+   *
+   * @type {{attach: Drupal.behaviors.dvfAdminPopup.attach}}
+   */
+  Drupal.behaviors.dvfAdminPopup = {
+    attach: function (context) {
+      $('.dvf-admin-popup a', context).on('click', function(e) {
+        e.preventDefault();
+        var w = window.open(this.href, 'advanced_help_window', 'width=600, height=600, scrollbars, resizable');
+        w.focus();
+        return false;
+      });
+    }
+  };
+
+})(jQuery, Drupal);

--- a/js/jquery.chart_export.js
+++ b/js/jquery.chart_export.js
@@ -1,0 +1,366 @@
+(function ($) {
+
+  "use strict";
+
+  /*
+   * ChartExport jQuery plugin.
+   * ---------------------------
+   * This plugin handles exporting a chart to a svg/png format.
+   *
+   * Usage.
+   * ------
+   * Bind this to the button you wish to trigger the download of the chart.
+   * Eg. $('button).chartExport({svg: 'svg.my-chart', format: 'svg'});
+   *
+   * Options/settings:
+   * - svg: (required) This is either a jQuery object or jQuery selector for the chart.
+   * - format: (string) The save as format (svg or png). Defaults to svg
+   * - filename: (string) The filename to use when saving, Defaults to 'chart'
+   * - includeExportStyles: (bool) Should we inject some styles that fix output bugs. Defaults to true
+   * - exportStylesheet: (string) Optional stylesheet to embed in the svg. Requires includeExportStyles = true.
+   * - errorMsg: (string) The error message to display if no browser support for downloading.
+   */
+
+  /**
+   * chartExport class.
+   *
+   * @param dom
+   *   The dom for the triggering element (eg. the button/link).
+   * @param settings
+   *   Settings for the class. @see defaults.
+   * @returns {chartExport}
+   *   Return self for chaining.
+   */
+  var ChartExport = function (dom, settings) {
+    var self = this;
+
+    // Defaults.
+    self.defaults = {
+      // The button this is getting bound to.
+      $button: $(dom),
+      // Chart SVG selector or jQuery object.
+      svg: 'svg',
+      // Format to save as.
+      format: 'svg',
+      // Filename (without extension).
+      filename: 'chart',
+      // Export as png dimensions. When values are empty, will automatically size.
+      width: '',
+      height: '',
+      // Embed additional styles in svg (fixes display bugs with c3js charts)
+      includeExportStyles: true,
+      exportStylesheets: [],
+      // If an export stylesheet is provided, these styles get replaced with the stylesheet content.
+      exportStyles: 'svg{font:10px sans-serif}line,path{fill:none;stroke:#000}.c3-bar{stroke:none!important}',
+      // Passed Validation requirements.
+      valid: true,
+      // Error message.
+      errorMsg: 'Sorry, your browser does not support this function.',
+      // Manual download message.
+      manualDownloadMessage: 'Your browser requires manual saving of this file, when redirected to the image, ' +
+        'right click and "Save {saveType} As..." to save it to your computer with the filename "{filename}"',
+      ieDownloadMessage: 'Right click the graph and select "Save picture as" then in the save dialog, set the ' +
+        '"Save as type" to '
+    };
+    
+    // Update defaults with passed settings.
+    self.settings = $.extend(self.defaults, settings);
+
+    /*
+     * Validate requirements.
+     */
+    self.validateRequirements = function () {
+      // TODO: Check html5 support.
+      try {
+        var isFileSaverSupported = !!new Blob;
+      } catch (e) {
+        self.settings.valid = false;
+      }
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Parse the svg object.
+     */
+    self.parseSvg = function () {
+      // Processed class.
+      var processedClass = 'chart-export-processed';
+
+      // If svg is not a jQuery object, make it one.
+      if (self.settings.svg.jquery === undefined) {
+        self.settings.svg = $(self.settings.svg);
+      }
+
+      // Ensure our svg is actually an svg (not a wrapper element).
+      self.settings.svg = self.settings.svg.is('svg') ? self.settings.svg : self.settings.svg.find('> svg');
+
+      // If no svg, validation failed.
+      if (self.settings.svg.length === 0) {
+        self.settings.valid = false;
+        return self;
+      }
+
+      // Don't process the svg more than once.
+      if (self.settings.svg.data('processed') === true) {
+        return self;
+      }
+
+      // Add some XML attributes.
+      self.settings.svg
+        .attr('version', 1.1)
+        .attr('xmlns', 'http://www.w3.org/2000/svg')
+        .attr('class', 'chart-export ' + self.settings.svg.attr('class'))
+        .data('processed', true);
+
+      // Remove clip path from groups.
+      self.settings.svg.find('g').removeAttr('clip-path');
+
+      // Add font family to texts.
+      self.settings.svg.find('text').attr('font-family', '\'arial\'');
+
+      // Include c3js styles.
+      self.includeExportStyles();
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Inject c3js styles if required.
+     */
+    self.includeExportStyles = function () {
+      // Check if styles need to be added first.
+      if (!self.settings.includeExportStyles) {
+        return self;
+      }
+
+      // jQuery 1.5+ is required to use exported styles as deferreds are used.
+      // See: https://api.jquery.com/jquery.when/
+      if (typeof $.when !== 'function') {
+        return self;
+      }
+
+      // If export stylesheets are provided, we load their content.
+      if (self.settings.exportStylesheets.length > 0) {
+        var deferreds = [], cssUrl, i;
+
+        // Ensure we don't have any duplicate stylesheets before fetching (a possible result
+        // of drupal_add_js running multiple times).
+        var cssSheets = self.settings.exportStylesheets.filter(function(element, index, array){
+          return array.indexOf(element) >= index;
+        });
+
+        // Fetch each stylesheet and append to exportStyles.
+        for (i in cssSheets) {
+          cssUrl = cssSheets[i];
+          deferreds.push(
+            $.get(cssUrl, self.appendStyles)
+          );
+        }
+
+        // After all the sheets are fetched, add them.
+        $.when.apply($, deferreds).then(function () {
+          self.embedStyles();
+        });
+
+      } else {
+        // No export stylesheet, use default styles.
+        self.embedStyles();
+      }
+
+      // Return self for chaining.
+      return self;
+    };
+
+    /*
+     * Callback for joining all external styles together.
+     */
+    self.appendStyles = function(css) {
+      self.settings.exportStyles += css;
+    };
+
+    // Embed current export styles.
+    self.embedStyles = function () {
+      // Create a style element.
+      self.$c3styles = $('<style>')
+        .attr('type', 'text/css')
+        .html("<![CDATA[\n" + self.settings.exportStyles + "\n]]>")
+        .appendTo($('defs', self.settings.svg));
+    };
+
+    /*
+     * Save as SVG.
+     */
+    self.saveSVG = function () {
+      // Save using blob and filesaver.js.
+      var blob = new Blob([self.svgHtml], {type: "image/svg+xml"});
+      saveAs(blob, self.getFilename());
+    };
+
+    /*
+     * Save as PNG.
+     */
+    self.savePNG = function () {
+      // Create a new image and add the svg as a src.
+      var image = new Image();
+
+      // Unescape/encodeURIComponent solves issues with non utf-8 strings.
+      image.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(self.svgHtml)));
+
+      // On image load, trigger its download with html5 download attr.
+      image.onload = function () {
+        // Once loaded, turn the image object into a 2d canvas.
+        var canvas = document.createElement('canvas'), context, dimensions;
+        dimensions = self.getDimensions(image);
+        canvas.width = dimensions.width;
+        canvas.height = dimensions.height;
+        context = canvas.getContext('2d');
+        context.drawImage(image, 0, 0, dimensions.width, dimensions.height);
+
+        // Save using canvas-toBlob.js.
+        canvas.toBlob(function (blob) {
+          saveAs(blob, self.getFilename());
+        });
+      };
+    };
+
+    /*
+     * Returns the width and height for the canvas based on settings and AR.
+     *
+     * @param image
+     *   The image with the src populated as the chart.
+     */
+    self.getDimensions = function (image) {
+      // Default to the image width/height.
+      var d = {width: image.width, height: image.height}, ar;
+
+      // If overridden we do some additional processing with the settings.
+      if (self.settings.width !== '') {
+        // Width set, height optional.
+        d.width = parseInt(self.settings.width);
+
+        // If no height, we calculate with the aspect ratio.
+        if (self.settings.height === '') {
+          ar = (image.height / image.width);
+          d.height = Math.round((d.width * ar));
+        } else {
+          // Defined width and height: May result in cropping or poor AR.
+          d.height = parseInt(self.settings.height);
+        }
+
+      } else if (self.settings.height !== '') {
+        // No width, only height defined, calculate width with AR.
+        d.height = parseInt(self.settings.height);
+        ar = (image.width / image.height);
+        d.width = Math.round((d.height * ar));
+      }
+
+      // Return the dimensions object.
+      return d;
+    };
+
+    /*
+     * Click action.
+     */
+    self.bindClick = function (e) {
+      e.preventDefault();
+
+      // If not passed validation, clicking the button returns an error msg.
+      if (self.settings.valid === false) {
+        return alert(self.settings.errorMsg);
+      }
+
+      // Safari currently doesn't support filesaver
+      // @see https://github.com/eligrey/FileSaver.js/issues/12
+      // So as a workaround we instruct the user on how to download.
+      if (self.isSafari()) {
+        var saveType = 'png' === self.settings.format ? 'Image' : 'Page';
+        alert(self.settings.manualDownloadMessage.replace('{filename}', self.getFilename()).replace('{saveType}', saveType));
+      }
+
+      // IE doesn't have very good blob support causing save to fail, so show a
+      // message instead. IE also has issues with duplicating xmlns and outerHTML.
+      // Works fine in EDGE.
+      if (self.isIE()) {
+        alert(self.settings.ieDownloadMessage + '"' + self.settings.format.toUpperCase() + '"');
+        return;
+      }
+
+      // Get the html for the svg (emulates cross browser outerHtml).
+      self.svgHtml = self.settings.svg[0].outerHTML;
+
+      // Call the save method based on format.
+      switch (self.settings.format.toLowerCase()) {
+        case 'svg':
+          self.saveSVG();
+          break;
+        case 'png':
+          self.savePNG();
+          break;
+      }
+    };
+
+    /*
+     * Safari check due to issue with filesaver.
+     */
+    self.isSafari = function () {
+      return navigator.vendor && navigator.vendor.indexOf('Apple') > -1 && navigator.userAgent && !navigator.userAgent.match('CriOS');
+    };
+
+    /*
+     * Internet Explorer check due to issue with blobs (and other things).
+     */
+    self.isIE = function () {
+      var ua = window.navigator.userAgent;
+      var msie = ua.indexOf("MSIE ");
+      return (msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./));
+    };
+
+    /*
+     * Return a clean filename with extension.
+     */
+    self.getFilename = function () {
+      var cleanFilename = self.settings.filename.replace(/[^a-z0-9_\-]/gi, '_').toLowerCase();
+      return cleanFilename + '.' + self.settings.format;
+    };
+
+    /*
+     * Init the class.
+     */
+    self.init = function () {
+      // Only one export per button.
+      if (self.settings.$button.hasClass('chart-export-processed')) {
+        return;
+      }
+
+      // Prepare requirements and svg.
+      self
+        .validateRequirements()
+        .parseSvg();
+
+      // Bind click and mark as processed.
+      self.settings.$button
+        .click(self.bindClick)
+        .addClass('chart-export-processed');
+    };
+
+    // Kick it off on construct.
+    self.init();
+
+    // Return self for chaining.
+    return self;
+  };
+
+
+  /**
+   * jQuery plugin/function.
+   */
+  $.fn.chartExport = function (settings) {
+    return this.each(function (i, dom) {
+      new ChartExport(dom, settings)
+    });
+  };
+
+})(jQuery);

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -348,8 +348,9 @@
       }
 
       var buttonTypes = ['png', 'svg'],
-          $buttonWrapper = $('<div/>')
-            .addClass('table-chart--actions');
+          $buttonWrapper = $(this.element)
+            .closest('.dvf-chart')
+            .nextAll('.table-chart--actions');
 
       $(buttonTypes).each(function (i, format) {
         $('<button/>')
@@ -365,8 +366,6 @@
           }))
           .appendTo($buttonWrapper);
       }.bind(this));
-
-      $buttonWrapper.insertAfter(this.element);
 
       return this;
     },

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -304,9 +304,7 @@
           pointShow = this.getDeepProperty(this.options, 'point.show'),
           pointRadius = this.getDeepProperty(this.options, 'point.radius');
 
-      if (pointShow) {
-        point.show = pointShow;
-      }
+      point.show = !!pointShow;
 
       if (pointRadius) {
         point.r = pointRadius;
@@ -399,13 +397,18 @@
       if (typeof $.fn.chartExport !== 'function') {
         return this;
       }
-
       var buttonTypes = ['png', 'svg'],
+          processedClass = 'processed-download-buttons',
           $buttonWrapper = $(this.element)
             .closest('.dvf-chart')
             .nextAll('.table-chart--actions');
 
+      if ($buttonWrapper.hasClass(processedClass)) {
+        return this;
+      }
+
       $(buttonTypes).each(function (i, format) {
+
         $('<button/>')
           .html('Download as ' + format)
           .addClass(this.options.chart.component + '--download')
@@ -416,7 +419,7 @@
             // Add optional settings if they exist.
             width: this.options.chart.styles.width || undefined,
             height: this.options.chart.styles.height || undefined,
-            filename: this.config.title.text || undefined,
+            filename: (this.config.title && this.config.title.text) ? this.config.title.text : undefined,
           }))
           .appendTo($buttonWrapper);
       }.bind(this));
@@ -425,6 +428,8 @@
       $('.download-data', $buttonWrapper).on('click', function() {
         window.open($(this).data('file-uri'));
       });
+
+      $buttonWrapper.addClass(processedClass);
 
       return this;
     },

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -179,16 +179,6 @@
         axis.x.tick.width = this.options.axis.x.styles.tick.width;
       }
 
-      if (this.options.axis.x.styles.padding.left) {
-        axis.x.padding = axis.x.padding || {};
-        axis.x.padding.left = parseInt(this.options.axis.x.styles.padding.left);
-      }
-
-      if (this.options.axis.x.styles.padding.right) {
-        axis.x.padding = axis.x.padding || {};
-        axis.x.padding.right = parseInt(this.options.axis.x.styles.padding.right);
-      }
-
       axis.x.label = {
         text: this.options.axis.x.label.text,
         position: (this.options.axis.styles.rotated) ? this.options.axis.y.styles.label.position : this.options.axis.x.styles.label.position
@@ -225,14 +215,12 @@
         axis.y.tick.values = this.options.axis.y.tick.values.custom;
       }
 
-      if (this.options.axis.x.styles.padding.top) {
-        axis.x.padding = axis.x.padding || {};
-        axis.x.padding.top = parseInt(this.options.axis.x.styles.padding.top);
+      if (this.options.axis.y.styles.padding && typeof(this.options.axis.y.styles.padding) == 'object') {
+        axis.y.padding = this.options.axis.y.styles.padding;
       }
 
-      if (this.options.axis.y.styles.padding.bottom) {
-        axis.y.padding = axis.y.padding || {};
-        axis.y.padding.bottom = parseInt(this.options.axis.y.styles.padding.bottom);
+      if (this.options.axis.x.styles.padding && typeof(this.options.axis.x.styles.padding) == 'object') {
+        axis.x.padding = this.options.axis.x.styles.padding;
       }
 
       axis.y.label = {

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -463,6 +463,12 @@
         }
       }.bind(this));
 
+      if (this.config.data.columns.length && this.config.data.columns[0].length) {
+        if (this.config.data.columns[0][0] === 'x' && this.config.data.columns.length !== ordered_columns.length) {
+          ordered_columns.unshift(this.config.data.columns[0]);
+        }
+      }
+
       if (this.config.data.columns.length === ordered_columns.length) {
         this.config.data.columns = ordered_columns;
       }

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -68,6 +68,11 @@
         this.config.color = {pattern: plugin.options.chart.palette.split(',')};
       }
 
+      // Display chart title is title.show is true.
+      if (plugin.options.chart.title.show) {
+        this.config.title = { text: plugin.options.chart.title.text };
+      }
+
       return this;
     },
 

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -100,7 +100,6 @@
       }
 
       data.type = this.options.chart.data.type;
-      data.labels = this.options.chart.data.labels.show;
 
       if (this.options.chart.data.stacked) {
         data.groups = [$.map(this.options.chart.data.groups, function(g, group) { return [group]; })];
@@ -110,6 +109,8 @@
       if (this.options.chart.data.names) {
         data.names = this.options.chart.data.names;
       }
+
+      data.labels = !!this.options.chart.data.labels.show;
 
       this.config.data = data;
 

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -76,7 +76,11 @@
       this.config.interaction = { enabled: this.options.chart.interaction };
 
       if (plugin.options.chart.palette) {
-        this.config.color = {pattern: plugin.options.chart.palette.split(',')};
+        this.config.color = {
+          pattern: plugin.options.chart.palette.split(',').map(function(color) {
+            return color.trim();
+          })
+        };
       }
 
       // Display chart title is title.show is true.

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -95,11 +95,6 @@
     parseDataOptions: function () {
       var data = { columns: this.options.chart.data.columns };
 
-      if (this.options.axis.x.tick.values.custom) {
-        data.x = 'x';
-        data.columns.push(['x'].concat(this.options.axis.x.tick.values.custom));
-      }
-
       if (this.options.axis.x.type === 'timeseries' && this.options.axis.x.tick.format.timeseries.input) {
         data.xFormat = this.options.axis.x.tick.format.timeseries.input;
       }
@@ -107,8 +102,19 @@
       data.type = this.options.chart.data.type;
 
       if (this.options.chart.data.stacked) {
-        data.groups = [$.map(this.options.chart.data.groups, function(g, group) { return [group]; })];
+
+        // Assign data groups depending on x axis grouping value.
+        data.groups =
+          this.options.axis.x.x_axis_grouping === 'values' ?
+          [$.map(data.columns, function(group) { return group[0]; })] :
+          [$.map(this.options.chart.data.groups, function(g, group) { return [group]; })];
+
         data.order = this.options.chart.data.order;
+      }
+
+      if (this.options.axis.x.tick.values.custom) {
+        data.x = 'x';
+        data.columns.unshift(['x'].concat(this.options.axis.x.tick.values.custom));
       }
 
       if (this.options.chart.data.names) {

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -34,11 +34,13 @@
         .parsePointOptions()
         .parseBarOptions()
         .parseGaugeOptions()
-        .generateChart();
+        .generateChart()
+        .addDownloadButtons();
     },
 
     generateChart: function () {
       c3.generate(this.config);
+      return this;
     },
 
     parseChartOptions: function () {
@@ -331,6 +333,40 @@
       }
 
       this.config.gauge = $.isEmptyObject(gauge) ? null : gauge;
+
+      return this;
+    },
+
+    /**
+     * Adds the various download buttons below the chart.
+     *
+     * @returns {Plugin}
+     */
+    addDownloadButtons: function () {
+      if (typeof $.fn.chartExport !== 'function') {
+        return this;
+      }
+
+      var buttonTypes = ['png', 'svg'],
+          $buttonWrapper = $('<div/>')
+            .addClass('table-chart--actions');
+
+      $(buttonTypes).each(function (i, format) {
+        $('<button/>')
+          .html('Download as ' + format)
+          .addClass(this.options.chart.component + '--download')
+          .chartExport($.extend({
+            format: format,
+            svg: $(this.element).is('svg') ? $(this.element) : $(this.element).find('svg'),
+          }, {
+            // Add optional settings if they exist.
+            width: this.options.chart.styles.width || undefined,
+            height: this.options.chart.styles.height || undefined,
+          }))
+          .appendTo($buttonWrapper);
+      }.bind(this));
+
+      $buttonWrapper.insertAfter(this.element);
 
       return this;
     },

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -408,6 +408,11 @@
           .appendTo($buttonWrapper);
       }.bind(this));
 
+      // Set download data click listener.
+      $('.download-data', $buttonWrapper).on('click', function() {
+        window.open($(this).data('file-uri'));
+      });
+
       return this;
     },
 

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -410,6 +410,7 @@
             // Add optional settings if they exist.
             width: this.options.chart.styles.width || undefined,
             height: this.options.chart.styles.height || undefined,
+            filename: this.config.title.text || undefined,
           }))
           .appendTo($buttonWrapper);
       }.bind(this));

--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -102,15 +102,22 @@
       }
 
       var self = this,
+        processedClass = 'processed-toggle-button',
         $buttonWrapper = $(this.element)
           .closest('.dvf-table')
           .nextAll('.table-chart--actions');
+
+      if ($buttonWrapper.hasClass(processedClass)) {
+        return this;
+      }
 
       $('<button/>')
         .html('Show table')
         .addClass('table-chart--toggle')
         .click(self.toggleView.bind(self))
         .appendTo($buttonWrapper);
+
+      $buttonWrapper.addClass(processedClass);
 
       return this;
     },

--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -119,6 +119,13 @@
 
       $buttonWrapper.addClass(processedClass);
 
+      // Set download data click listener.
+      if ($(this.element).is('table')) {
+        $('.download-data', $(this.element).closest('.dvf-table')).on('click', function() {
+          window.open($(this).data('file-uri'));
+        });
+      }
+
       return this;
     },
 

--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -97,6 +97,10 @@
      */
     addToggleButton: function () {
 
+      if (this.options.table.disable) {
+        return this;
+      }
+
       var self = this,
         $buttonWrapper = $(this.element)
           .closest('.dvf-table')

--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -29,9 +29,13 @@
         .parseData()
         .parseColumns()
         .parseTableOptions()
+        .addToggleButton()
         .generateTable();
     },
 
+    /**
+     * Initialises the jQuery datatable plugin with parsed configurations.
+     */
     generateTable: function () {
       $(this.element).dataTable(this.config);
     },
@@ -51,6 +55,11 @@
       return this;
     },
 
+    /**
+     * Generate an array of column headers.
+     *
+     * @returns {Plugin}
+     */
     parseColumns: function () {
       var columns = [];
 
@@ -68,13 +77,55 @@
       return this;
     },
 
+    /**
+     * Uses the set options to generate the datatables settings configuration.
+     *
+     * @returns {Plugin}
+     */
     parseTableOptions: function () {
       if (this.options.tableOptions) {
         this.config = $.extend(this.config, this.options.tableOptions);
       }
 
       return this;
-    }
+    },
+
+    /**
+     * Add toggle table / chart button.
+     *
+     * @returns {Plugin}
+     */
+    addToggleButton: function () {
+
+      var self = this,
+        $buttonWrapper = $(this.element)
+          .closest('.dvf-table')
+          .nextAll('.table-chart--actions');
+
+      $('<button/>')
+        .html('Show table')
+        .addClass('table-chart--toggle')
+        .click(self.toggleView.bind(self))
+        .appendTo($buttonWrapper);
+
+      return this;
+    },
+
+    /**
+     * Toggles the visibility of the table / chart, and the button text.
+     *
+     * @returns {Plugin}
+     */
+    toggleView: function () {
+
+      var $dvfParent = $(this.element).closest('.dvf-table').parent(),
+        $toggleButton = $('.table-chart--toggle', $dvfParent);
+
+      $('.dvf-chart, .dvf-table', $dvfParent).toggleClass('visually-hidden');
+      $toggleButton.text($toggleButton.text().toLowerCase().trim() === 'show chart' ? 'Show table' : 'Show chart');
+
+      return this;
+    },
 
   };
 

--- a/src/ConfigurablePluginTrait.php
+++ b/src/ConfigurablePluginTrait.php
@@ -33,7 +33,9 @@ trait ConfigurablePluginTrait {
         return $haystack[$key];
       }
 
-      $haystack = $haystack[$key];
+      if (!empty($haystack[$key])) {
+        $haystack = $haystack[$key];
+      }
     }
 
     return NULL;

--- a/src/Controller/DvfHelpController.php
+++ b/src/Controller/DvfHelpController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\dvf\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Class DvfHelpController.
+ */
+class DvfHelpController extends ControllerBase {
+
+  /**
+   * Returns the help page information ready to load in partial twig template.
+   *
+   * @param string $topic
+   *   The topic or help page subject to load.
+   *
+   * @return array
+   *   An array that renders the help page in the twig template.
+   */
+  public function helpPage($topic) {
+
+    $file_path = drupal_get_path('module', 'dvf') . '/templates/help/';
+
+    if (!file_exists($file_path . $topic . '.html.twig')) {
+      $topic = FALSE;
+    }
+
+    return [
+      '#theme' => 'help_page',
+      '#description' => $this->t('DVF help page'),
+      '#attributes' => ['class' => ['dvf-help-page']],
+      '#topic' => $topic,
+    ];
+  }
+
+  /**
+   * Returns the title for a help page.
+   *
+   * @param string $topic
+   *   The topic of the help page.
+   *
+   * @return string
+   *   The title of the help page.
+   */
+  public function getHelpPageTitle($topic) {
+    return ucfirst(str_replace('-', ' ', $topic));
+  }
+
+}

--- a/src/DvfHelpers.php
+++ b/src/DvfHelpers.php
@@ -67,4 +67,27 @@ class DvfHelpers {
     return (json_decode($raw_json, TRUE) == NULL) ? FALSE : TRUE;
   }
 
+  /**
+   * Recursively removes empty elements from nested array.
+   *
+   * @param array $array
+   *   The array to remove the empty elements from.
+   *
+   * @return array
+   *   The filtered array.
+   */
+  public function filterArrayRecursive(array $array) {
+    foreach ($array as $key => $value) {
+      if (is_array($value)) {
+        $array[$key] = self::filterArrayRecursive($array[$key]);
+      }
+
+      if (empty($array[$key])) {
+        unset($array[$key]);
+      }
+    }
+
+    return $array;
+  }
+
 }

--- a/src/DvfHelpers.php
+++ b/src/DvfHelpers.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\dvf;
+
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+
+/**
+ * Class DvfHelpers.
+ */
+class DvfHelpers {
+
+  /**
+   * The help page base path.
+   *
+   * @var string
+   */
+  protected $helpPageBasePath;
+
+  /**
+   * Constructs a new DvfHelpers object.
+   */
+  public function __construct() {
+    $this->helpPageBasePath = '/dvf/help/';
+  }
+
+  /**
+   * Transforms a regular string into a machine_name.
+   *
+   * @param string $string
+   *   The regular string.
+   *
+   * @return string
+   *   The machine name version of the string.
+   */
+  public function transformMachineName($string) {
+    return preg_replace('/[^A-Za-z0-9\-\_]/', '', strtolower(trim(str_replace(' ', '_', $string))));
+  }
+
+  /**
+   * Returns a help page link, using the base path defined above.
+   *
+   * @param string $title
+   *   The title of the link.
+   *
+   * @return string
+   *   The link.
+   */
+  public function getHelpPageLink($title) {
+    $link = Link::fromTextAndUrl('Help', Url::fromUserInput($this->helpPageBasePath . $title));
+    return $link->toString();
+  }
+
+}

--- a/src/DvfHelpers.php
+++ b/src/DvfHelpers.php
@@ -4,6 +4,7 @@ namespace Drupal\dvf;
 
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Class DvfHelpers.
@@ -40,15 +41,17 @@ class DvfHelpers {
   /**
    * Returns a help page link, using the base path defined above.
    *
-   * @param string $title
-   *   The title of the link.
+   * @param string $template_name
+   *   The name of the template to link to.
+   *
+   *   E.g. "label-overrides" loads templates/help/label-overrides.html.twig.
    *
    * @return string
    *   The link.
    */
-  public function getHelpPageLink($title) {
-    $link = Link::fromTextAndUrl('Help', Url::fromUserInput($this->helpPageBasePath . $title));
-    return $link->toString();
+  public function getHelpPageLink($template_name) {
+    $link = Link::fromTextAndUrl('Help', Url::fromUserInput($this->helpPageBasePath . $template_name));
+    return new FormattableMarkup('<span class="dvf-admin-popup">' . $link->toString() . ' &#x29c9;</span>', []);
   }
 
 }

--- a/src/DvfHelpers.php
+++ b/src/DvfHelpers.php
@@ -54,4 +54,17 @@ class DvfHelpers {
     return new FormattableMarkup('<span class="dvf-admin-popup">' . $link->toString() . ' &#x29c9;</span>', []);
   }
 
+  /**
+   * Check if a value is correctly formatted JSON.
+   *
+   * @param string $raw_json
+   *   The JSON string.
+   *
+   * @return bool
+   *   True if JSON, false if not.
+   */
+  public function validateJson($raw_json) {
+    return (json_decode($raw_json, TRUE) == NULL) ? FALSE : TRUE;
+  }
+
 }

--- a/src/FieldTypeTrait.php
+++ b/src/FieldTypeTrait.php
@@ -12,6 +12,13 @@ use Drupal\Core\Form\FormStateInterface;
 trait FieldTypeTrait {
 
   /**
+   * The default plugin ID to prevent errors if no visualisation style is selected.
+   *
+   * @var string
+   */
+  private $defaultPluginId = 'dvf_bar_chart';
+
+  /**
    * Returns a form base for the field-level settings.
    *
    * @param array $form
@@ -105,9 +112,15 @@ trait FieldTypeTrait {
     if (!empty($item['options']['visualisation_style'])) {
       $plugin_configuration['style']['plugin_id'] = $item['options']['visualisation_style'];
     }
+    else {
+      $plugin_configuration['style']['plugin_id'] = $this->defaultPluginId;
+    }
 
     if (!empty($item['options']['visualisation_style_options'])) {
       $plugin_configuration['style']['options'] = $item['options']['visualisation_style_options'];
+    }
+    else {
+      \Drupal::messenger()->addWarning(t('Insufficient style options detected for this visualisation. Please review the settings.'));
     }
 
     if ($default_source) {

--- a/src/FieldTypeTrait.php
+++ b/src/FieldTypeTrait.php
@@ -119,9 +119,6 @@ trait FieldTypeTrait {
     if (!empty($item['options']['visualisation_style_options'])) {
       $plugin_configuration['style']['options'] = $item['options']['visualisation_style_options'];
     }
-    else {
-      \Drupal::messenger()->addWarning(t('Insufficient style options detected for this visualisation. Please review the settings.'));
-    }
 
     if ($default_source) {
       $plugin_configuration['source'] = NestedArray::mergeDeep($plugin_configuration['source'], $default_source);

--- a/src/Plugin/Field/FieldFormatter/VisualisationDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/VisualisationDefaultFormatter.php
@@ -2,9 +2,13 @@
 
 namespace Drupal\dvf\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\dvf\DvfHelpers;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'dvf_default' field formatter.
@@ -18,7 +22,56 @@ use Drupal\Core\Field\FieldItemListInterface;
  *   }
  * )
  */
-class VisualisationDefaultFormatter extends FormatterBase {
+class VisualisationDefaultFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * DVF Helpers.
+   *
+   * @var \Drupal\dvf\DvfHelpers
+   */
+  protected $dvfHelpers;
+
+  /**
+   * Constructs a FormatterBase object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings settings.
+   * @param \Drupal\dvf\DvfHelpers $dvf_helpers
+   *   The DVF helpers.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, DvfHelpers $dvf_helpers) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->dvfHelpers = $dvf_helpers;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('dvf.helpers')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -27,6 +80,21 @@ class VisualisationDefaultFormatter extends FormatterBase {
     return [
       'chart' => [
         'palette' => '',
+        'styles' => [
+          'width' => '',
+          'height' => '',
+        ],
+      ],
+      'axis' => [
+        'x' => [
+          'styles' => [
+            'label' => ['position' => ''],
+            'tick' => ['centered' => TRUE],
+          ],
+        ],
+        'y' => [
+          'styles' => ['label' => ['position' => '']],
+        ],
       ],
     ] + parent::defaultSettings();
   }
@@ -42,11 +110,61 @@ class VisualisationDefaultFormatter extends FormatterBase {
       '#tree' => TRUE,
     ];
 
+    foreach (['width', 'height'] as $measure) {
+      $element['chart']['styles'][$measure] = [
+        '#title' => ucfirst($measure),
+        '#type' => 'textfield',
+        '#default_value' => $settings['chart']['styles'][$measure],
+        '#description' => $this->t('A pixel value (without unit). Leave blank for auto sizing.'),
+      ];
+    }
+
     $element['chart']['palette'] = [
       '#title' => $this->t('Visualisation Palette'),
       '#type' => 'textfield',
       '#default_value' => $settings['chart']['palette'],
       '#description' => $this->t('Palette is a comma separated list of hex values. If not set, default palette is applied. Not all visualisations will support this.'),
+    ];
+
+    $element['axis']['x']['styles']['label']['position'] = [
+      '#type' => 'select',
+      '#title' => $this->t('X axis title position'),
+      '#description' => $this->t('Define the title position on the X axis.'),
+      '#options' => [
+        'inner-right' => $this->t('Inner right'),
+        'inner-center' => $this->t('Inner center'),
+        'inner-left' => $this->t('Inner left'),
+        'outer-right' => $this->t('Outer right'),
+        'outer-center' => $this->t('Outer center'),
+        'outer-left' => $this->t('Outer left'),
+      ],
+      '#default_value' => $settings['axis']['x']['styles']['label']['position'],
+      '#empty_option' => $this->t('- Select -'),
+      '#empty_value' => '',
+    ];
+
+    $element['axis']['x']['styles']['tick']['centered'] = [
+      '#title' => $this->t('Tick label centered'),
+      '#description' => $this->t('Check to display tick directly above the label on the X axis.'),
+      '#type' => 'checkbox',
+      '#default_value' => $settings['axis']['x']['styles']['tick']['centered'],
+    ];
+
+    $element['axis']['y']['styles']['label']['position'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Y axis title position'),
+      '#description' => $this->t('Define the title position on the Y axis.'),
+      '#options' => [
+        'inner-top' => $this->t('Inner top'),
+        'inner-middle' => $this->t('Inner middle'),
+        'inner-bottom' => $this->t('Inner bottom'),
+        'outer-top' => $this->t('Outer top'),
+        'outer-middle' => $this->t('Outer middle'),
+        'outer-bottom' => $this->t('Outer bottom'),
+      ],
+      '#default_value' => $settings['axis']['y']['styles']['label']['position'],
+      '#empty_option' => $this->t('- Select -'),
+      '#empty_value' => '',
     ];
 
     return $element;
@@ -57,9 +175,15 @@ class VisualisationDefaultFormatter extends FormatterBase {
    */
   public function settingsSummary() {
     $settings = $this->getSettings();
-
     $summary = [];
+
     $summary[] = $this->t('Visualisation palette @palette', ['@palette' => $settings['chart']['palette']]);
+    $summary[] = $this->t('Visualisation width @width', ['@width' => $settings['chart']['styles']['width']]);
+    $summary[] = $this->t('Visualisation width @height', ['@height' => $settings['chart']['styles']['height']]);
+
+    $summary[] = $this->t('X axis title position @x', ['@x' => $settings['axis']['x']['styles']['label']['position']]);
+    $summary[] = $this->t('X Tick label centered @label', ['@label' => $settings['axis']['x']['styles']['tick']['centered'] ? 'True' : 'False']);
+    $summary[] = $this->t('Y axis title position @y', ['@y' => $settings['axis']['y']['styles']['label']['position']]);
 
     return $summary;
   }
@@ -69,11 +193,21 @@ class VisualisationDefaultFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $element = [];
+    $formatter_settings = $this->getSettings();
 
     /** @var \Drupal\dvf\Plugin\VisualisationItemInterface $item */
     foreach ($items as $delta => $item) {
+      $visualisation_style_options = $item->getVisualisationPlugin()->getStyleConfiguration();
+
+      if (!empty($visualisation_style_options['options']) && !empty($formatter_settings)) {
+        $formatter_settings = array_replace_recursive(
+          $this->dvfHelpers->filterArrayRecursive($formatter_settings),
+          $this->dvfHelpers->filterArrayRecursive($visualisation_style_options['options'])
+        );
+      }
+
       $element[$delta] = $item
-        ->getVisualisationPlugin([], ['options' => $this->getSettings()])
+        ->getVisualisationPlugin([], ['options' => $formatter_settings])
         ->render();
     }
 

--- a/src/Plugin/Visualisation/Source/VisualisationSourceBase.php
+++ b/src/Plugin/Visualisation/Source/VisualisationSourceBase.php
@@ -196,4 +196,25 @@ abstract class VisualisationSourceBase extends PluginBase implements Visualisati
     return $this->visualisation;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheExpiry() {
+    // Get the cache time set from visualisation.
+    $configuration_options = $this->visualisation->getConfiguration('style');
+    $cache_object_expire = FALSE;
+
+    if (!empty($configuration_options['style']['options']['data']['cache_expiry'])) {
+      $cache_object_expire = $configuration_options['style']['options']['data']['cache_expiry'];
+    }
+
+    // If not numeric (e.g. global_default, false) get the global default.
+    if (!is_numeric($cache_object_expire)) {
+      $cache_global_config = \Drupal::config('system.performance')->get('cache');
+      $cache_object_expire = $cache_global_config['page']['max_age'];
+    }
+
+    return \Drupal::time()->getRequestTime() + $cache_object_expire;
+  }
+
 }

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -685,6 +685,21 @@ abstract class AxisChart extends TableVisualisationStyleBase {
         '#type' => 'container',
         '#attributes' => ['class' => ['table-chart--actions']],
       ];
+
+      // If $file_uri is empty/false, do not display download data button.
+      $file_uri = $this->getDatasetDownloadUri($this->visualisation->getEntity());
+      if (!empty($file_uri)) {
+        $build[$group_key]['actions']['file_uri'] = [
+          '#type' => 'html_tag',
+          '#tag' => 'button',
+          '#value' => $this->t('Download data'),
+          '#attributes' => [
+            'class' => ['download-data'],
+            'data-file-uri' => $file_uri,
+          ],
+        ];
+      }
+
     }
 
     return $build;
@@ -787,7 +802,14 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    *   An array of column override settings.
    */
   protected function getColumnOverrides() {
-    $allowed_overrides = ['color', 'type', 'legend', 'style', 'weight', 'class'];
+    $allowed_overrides = [
+      'color',
+      'type',
+      'legend',
+      'style',
+      'weight',
+      'class',
+    ];
     $column_overrides_sorted = [];
     $pair = 2;
 

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -100,6 +100,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
           'text' => '',
         ],
         'interaction' => TRUE,
+        'table' => [],
         'data' => [
           'labels' => [
             'show' => FALSE,
@@ -526,6 +527,13 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       '#title' => $this->t('Enable chart interaction'),
       '#description' => $this->t('Check to enable all of interactions (E.g. Showing / hiding the tooltip when hovering on labels, etc).'),
       '#default_value' => $this->config('chart', 'interaction'),
+    ];
+
+    $form['chart']['table']['disable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable table'),
+      '#description' => $this->t('Disable the "Show table" toggle button on a chart / graph.'),
+      '#default_value' => $this->config('chart', 'table', 'disable'),
     ];
 
     $form['chart']['data']['labels']['show'] = [

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -818,6 +818,11 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       'chart' => $this->config('chart'),
     ];
 
+    if (empty($records)) {
+      $this->messenger->addError(t('Invalid records.'));
+      return [];
+    }
+
     // Axis X and Y tick values from user input.
     foreach (['x', 'y'] as $axis) {
       if ($this->config('axis', $axis, 'tick', 'values', 'custom')) {
@@ -830,7 +835,9 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       $settings['axis']['x']['tick']['values']['custom'] = [];
 
       foreach ($records as $record) {
-        $settings['axis']['x']['tick']['values']['custom'][] = trim($record->{$this->config('axis', 'x', 'tick', 'values', 'field')});
+        if (property_exists($record, $this->config('axis', 'x', 'tick', 'values', 'field'))) {
+          $settings['axis']['x']['tick']['values']['custom'][] = trim($record->{$this->config('axis', 'x', 'tick', 'values', 'field')});
+        }
       }
     }
 
@@ -867,13 +874,13 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     // Check if values are auto.
     $tick_values_field = $this->config('axis', 'x', 'tick', 'values', 'field');
 
-    if ($settings['axis']['x']['type'] === '') {
+    if ($settings['axis']['x']['type'] === '' && !empty($record) && property_exists($record, $tick_values_field)) {
       is_numeric($record->{$tick_values_field}) ?
         $settings['axis']['x']['type'] = 'indexed' :
         $settings['axis']['x']['type'] = 'category';
     }
 
-    if ($settings['axis']['y']['type'] === '') {
+    if ($settings['axis']['y']['type'] === '' && !empty($record) && property_exists($record, $field)) {
       is_numeric($record->{$field}) ?
         $settings['axis']['y']['type'] = 'indexed' :
         $settings['axis']['y']['type'] = 'category';

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -49,7 +49,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
               'right' => '',
             ],
             'label' => [
-              'position' => 'inner-right',
+              'position' => '',
             ],
             'tick' => [
               'rotate' => '',
@@ -80,7 +80,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
               'bottom' => '',
             ],
             'label' => [
-              'position' => 'inner-top',
+              'position' => '',
             ],
           ],
         ],
@@ -290,6 +290,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
         'outer-left' => $this->t('Outer left'),
       ],
       '#default_value' => $this->config('axis', 'x', 'styles', 'label', 'position'),
+      '#empty_option' => $this->t('- Select -'),
+      '#empty_option_value' => '',
     ];
 
     $form['axis']['x']['styles']['tick']['rotate'] = [
@@ -416,6 +418,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
         'outer-bottom' => $this->t('Outer bottom'),
       ],
       '#default_value' => $this->config('axis', 'y', 'styles', 'label', 'position'),
+      '#empty_option' => $this->t('- Select -'),
+      '#empty_option_value' => '',
     ];
 
     $form['grid'] = [

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -419,7 +419,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     $form['grid']['lines'] = [
       '#type' => 'details',
       '#title' => $this->t('Grid lines'),
-      '#description' => t('Show additional grid lines along X or Y axis.'),
+      '#description' => t('Show additional grid lines along X or Y axis. @help',
+        ['@help' => \Drupal::service('dvf.helpers')->getHelpPageLink('grid-lines')]),
       '#open' => ($grid_lines_count > 0),
       '#tree' => TRUE,
       '#attributes' => [

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -97,6 +97,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       'chart' => [
         'title' => [
           'show' => TRUE,
+          'text' => '',
         ],
         'interaction' => TRUE,
         'data' => [
@@ -760,6 +761,9 @@ abstract class AxisChart extends TableVisualisationStyleBase {
 
     // Override fields labels if set in chart options.
     $settings['chart']['data']['names'] = $this->fieldLabels();
+
+    // Set the chart title.
+    $settings['chart']['title']['text'] = $this->visualisation->getEntity()->label();
 
     return $settings;
   }

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -117,6 +117,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
             'left' => '',
           ],
         ],
+        'component' => 'table-chart',
       ],
     ] + parent::defaultConfiguration();
   }

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -142,7 +142,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
 
     $form['axis']['styles']['rotated'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Rotated'),
+      '#title' => $this->t('Rotate orientation'),
       '#description' => $this->t('Check to switch the X and Y axis position.'),
       '#default_value' => $this->config('axis', 'styles', 'rotated'),
     ];

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -679,6 +679,12 @@ abstract class AxisChart extends TableVisualisationStyleBase {
         '#attributes' => ['class' => ['dvf-table', 'visually-hidden']],
         'content' => $this->buildTable($group_records),
       ];
+
+      // A wrapper for the action buttons (toggle, download etc).
+      $build[$group_key]['actions'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['table-chart--actions']],
+      ];
     }
 
     return $build;

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -761,6 +761,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     // Override fields labels if set in chart options.
     $settings['chart']['data']['names'] = $this->fieldLabels();
 
+    $settings['chart']['data']['column_overrides'] = $this->getColumnOverrides();
+
     return $settings;
   }
 
@@ -776,6 +778,62 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    */
   protected function rowHeaderField() {
     return $this->config('axis', 'x', 'tick', 'values', 'field');
+  }
+
+  /**
+   * Gets the column overrides settings in a nicely formatted array.
+   *
+   * @return array
+   *   An array of column override settings.
+   */
+  protected function getColumnOverrides() {
+    $allowed_overrides = ['color', 'type', 'legend', 'style', 'weight', 'class'];
+    $column_overrides_sorted = [];
+    $pair = 2;
+
+    foreach ($this->config('data', 'column_overrides') as $field_name => $column_override) {
+      $field_overrides = explode(PHP_EOL, $column_override);
+
+      foreach ($field_overrides as $field_override) {
+        $field_override_array = explode('|', trim($field_override), $pair);
+
+        if (count($field_override_array) === $pair && in_array($field_override_array[0], $allowed_overrides)) {
+          $column_overrides_sorted[$field_name][$field_override_array[0]] = $field_override_array[1];
+        }
+      }
+    }
+
+    $column_overrides_sorted = array_merge(array_fill_keys($this->fieldLabelsUnique(), []), $column_overrides_sorted);
+    return $this->setArrayOrder($column_overrides_sorted);
+  }
+
+  /**
+   * Re-orders the keys as per provided order array.
+   *
+   * @param array $array_to_order
+   *   An array keyed by the key (original) name, the value for each should be
+   *   an array containing a weight key. The lower the weight the higher it
+   *   appears in the list. If no weight found, default order is used.
+   * @param string $weight_key
+   *   The key that contains the weight.
+   *
+   * @return array
+   *   An ordered array.
+   */
+  protected function setArrayOrder(array $array_to_order, $weight_key = 'weight') {
+    $i = 0;
+    foreach ($array_to_order as $key => $value) {
+      $array_to_order[$key][$weight_key] = isset($value[$weight_key]) ? (int) $value[$weight_key] : $i;
+      $i++;
+    }
+
+    $weights = [];
+    foreach ($array_to_order as $key => $row) {
+      $weights[$key] = $row[$weight_key];
+    }
+    array_multisort($weights, SORT_ASC, $array_to_order);
+
+    return $array_to_order;
   }
 
 }

--- a/src/Plugin/Visualisation/Style/GaugeChart.php
+++ b/src/Plugin/Visualisation/Style/GaugeChart.php
@@ -59,7 +59,7 @@ class GaugeChart extends AxisChart {
     $form['gauge_chart']['gauge']['units'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Unit label'),
-      '#description' => $this->t('Enter a unit type, eg %, mm, kg etc'),
+      '#description' => $this->t('Enter a unit type, E.g. %, mm, kg etc'),
       '#default_value' => $this->config('gauge_chart', 'gauge', 'units'),
     ];
 
@@ -73,14 +73,14 @@ class GaugeChart extends AxisChart {
     $form['gauge_chart']['gauge']['width'] = [
       '#type' => 'number',
       '#title' => $this->t('Width'),
-      '#description' => $this->t('Adjust arc thickness, eg 39'),
+      '#description' => $this->t('Adjust arc thickness, E.g. 39'),
       '#default_value' => $this->config('gauge_chart', 'gauge', 'width'),
     ];
 
     $form['gauge_chart']['gauge']['min'] = [
       '#type' => 'number',
       '#title' => $this->t('Min'),
-      '#description' => $this->t('0 is default, can handle negative min, eg vacuum / voltage / current flow etc'),
+      '#description' => $this->t('0 is default, can handle negative min, E.g. vacuum / voltage / current flow etc'),
       '#default_value' => $this->config('gauge_chart', 'gauge', 'min'),
     ];
 

--- a/src/Plugin/Visualisation/Style/TableVisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/TableVisualisationStyleBase.php
@@ -41,9 +41,12 @@ abstract class TableVisualisationStyleBase extends VisualisationStyleBase {
    *   An array of table build settings.
    */
   protected function tableBuildSettings(array $records) {
+    $config = $this->getConfiguration();
+
     return [
       'data' => $this->getTableRows($records),
       'columns' => $this->getTableHeader(),
+      'table' => $config['chart']['table'],
     ];
   }
 

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -3,6 +3,8 @@
 namespace Drupal\dvf\Plugin\Visualisation\Style;
 
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -366,6 +368,40 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    */
   public function getVisualisation() {
     return $this->visualisation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDatasetDownloadUri(EntityInterface $entity, array $dvf_field_types = ['dvf_url', 'dvf_file']) {
+    $field_definitions = $entity->getFieldDefinitions();
+    $dvf_field_values = [];
+    $dvf_file_uri = '';
+
+    foreach ($field_definitions as $field_definition) {
+      if (in_array($field_definition->getType(), $dvf_field_types)) {
+
+        $field_name = $field_definition->get('field_name');
+
+        if (!empty($entity->get($field_name)->first())) {
+          $dvf_field_values = $entity->get($field_name)->first()->getValue();
+        }
+      }
+    }
+
+    if (!empty($dvf_field_values['uri'])) {
+      $dvf_file_uri = $dvf_field_values['uri'];
+    }
+
+    // Check to see if we have a valid URI.
+    return $this->isValidDownloadUri($dvf_file_uri);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isValidDownloadUri($uri) {
+    return (UrlHelper::isValid($uri) || filter_var($uri, FILTER_VALIDATE_URL)) ? $uri : FALSE;
   }
 
 }

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -369,7 +369,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     $label_overrides = preg_split('/\r\n|[\r\n]/', $label_overrides);
 
     foreach ($label_overrides as $label_override) {
-      $label_parts = explode('|', $label_override, 2);
+      $label_parts = explode('|', trim($label_override), 2);
 
       if (count($label_parts) === 2 && array_key_exists($label_parts[0], $labels)) {
         $labels[$label_parts[0]] = $label_parts[1];
@@ -380,13 +380,19 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
   }
 
   /**
-   * Gets the field labels without duplicates.
+   * Gets the original field labels without any overrides applied.
    *
    * @return array
    *   The unique field labels.
    */
-  protected function fieldLabelsUnique() {
-    return array_unique($this->fieldLabels(), SORT_REGULAR);
+  protected function fieldLabelsOriginal() {
+    $labels = $this->getSourceFieldOptions();
+
+    if (!empty($labels['_id'])) {
+      unset($labels['_id']);
+    }
+
+    return array_keys($labels);
   }
 
   /**
@@ -475,8 +481,28 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       }, $this->getVisualisation()->data());
     }
     else {
-      return $this->fieldLabelsUnique();
+      return $this->fieldLabelsOriginal();
     }
+  }
+
+  /**
+   * Checks to see if columns are numeric.
+   *
+   * @param array $array
+   *   The array of column values.
+   *
+   * @return bool
+   *   True if numeric, false if not.
+   */
+  public function columnsAreNumeric(array $array) {
+    $array = reset($array);
+    array_shift($array);
+
+    if (count($array) === count(array_filter($array, 'is_numeric'))) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -103,6 +103,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
         'fields' => [],
         'field_labels' => '',
         'split_field' => '',
+        'cache_expiry' => '',
       ],
     ];
   }
@@ -155,7 +156,36 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       '#default_value' => $this->config('data', 'split_field'),
     ];
 
+    $form['data']['cache_expiry'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Cache expiry'),
+      '#description' => $this->t('How long the results for this dataset will be cached.'),
+      '#options' => $this->getCacheOptions(),
+      '#default_value' => $this->config('data', 'cache_expiry'),
+    ];
+
     return $form;
+  }
+
+  /**
+   * Gets the options array for caching.
+   *
+   * @return array
+   *   The options array.
+   */
+  protected function getCacheOptions() {
+
+    return [
+      '_global_default' => 'Global default',
+      '0' => 'No cache',
+      '1800' => '30 minutes',
+      '3600' => '1 hour',
+      '21600' => '6 hours',
+      '86400' => '1 day',
+      '604800' => '1 week',
+      '2592000' => '1 month',
+      '15552000' => '6 months',
+    ];
   }
 
   /**

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -134,6 +134,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
         'split_field' => '',
         'cache_expiry' => '',
         'column_overrides' => [],
+        'data_filters' => [],
       ],
     ];
   }
@@ -223,6 +224,31 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
         '#default_value' => $this->config('data', 'column_overrides', $override),
       ];
     }
+
+    $form['data']['data_filters'] = [
+      '#prefix' => '<div>',
+      '#suffix' => '</div>',
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#type' => 'details',
+      '#title' => t('CKAN data filters'),
+      '#description' => t('Filters can be used to refine/reduce the records returned from the CKAN datasource. @help',
+        ['@help' => $this->dvfHelpers->getHelpPageLink('data-filters')]),
+    ];
+
+    $form['data']['data_filters']['q'] = [
+      '#type' => 'textfield',
+      '#title' => t('Full text query'),
+      '#description' => t('Optionally query entire dataset for any string value.'),
+      '#default_value' => $this->config('data', 'data_filters', 'q'),
+    ];
+
+    $form['data']['data_filters']['filters'] = [
+      '#type' => 'textfield',
+      '#title' => t('Filters'),
+      '#description' => t('Filter on key/value dictionary. For example: {"code": "4000", "year": "2016"} or {"year": ["2014", "2015", "2015"]}. Case sensitive.'),
+      '#default_value' => $this->config('data', 'data_filters', 'filters'),
+    ];
 
     return $form;
   }

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -122,6 +122,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $form['#after_build'][] = [get_called_class(), 'afterBuildSettingsForm'];
+    $form['#attached']['library'][] = 'dvf/dvfAdmin';
+    $dvf_helpers = \Drupal::service('dvf.helpers');
 
     $form['data'] = [
       '#type' => 'details',
@@ -132,7 +134,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     $form['data']['fields'] = [
       '#type' => 'select',
       '#title' => $this->t('Fields'),
-      '#description' => $this->t("What fields to include in the visualisation. Select at least one field to display it's data. A field is typically a column in a CSV."),
+      '#description' => $this->t('What fields to include in the visualisation. Select at least one field to display its data. A field is typically a column in a CSV. @help',
+        ['@help' => $dvf_helpers->getHelpPageLink('keys')]),
       '#options' => $this->getSourceFieldOptions(),
       '#multiple' => TRUE,
       '#size' => 5,
@@ -142,7 +145,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     $form['data']['field_labels'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Field label overrides'),
-      '#description' => $this->t('Optionally override one or more field labels. Add one original_label|new_label per line and separate with a pipe.'),
+      '#description' => $this->t('Optionally override one or more field labels. Add one original_label|new_label per line and separate with a pipe. @help',
+        ['@help' => $dvf_helpers->getHelpPageLink('label-overrides')]),
       '#rows' => 2,
       '#default_value' => $this->config('data', 'field_labels'),
       '#placeholder' => 'Old label|New label',
@@ -151,7 +155,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     $form['data']['split_field'] = [
       '#type' => 'select',
       '#title' => $this->t('Split field'),
-      '#description' => $this->t('Optionally split into multiple visualisations based on the value of this field. A new visualisation will be made for each unique value in this field.'),
+      '#description' => $this->t('Optionally split into multiple visualisations based on the value of this field. A new visualisation will be made for each unique value in this field. @help',
+        ['@help' => $dvf_helpers->getHelpPageLink('split')]),
       '#options' => $this->getSourceFieldOptions(),
       '#empty_option' => $this->t('- None -'),
       '#empty_value' => '',
@@ -179,7 +184,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       '#description' => '<p>' . t('Optionally override a style for a specific column, add one key|value per line and separate key value with a pipe. @help.<br />Examples: <strong>@examples</strong>.',
         [
           '@examples' => new FormattableMarkup(implode('</strong> or <strong>', $column_override_examples), []),
-          '@help' => new FormattableMarkup(\Drupal::service('dvf.helpers')->getHelpPageLink('column-overrides'), []),
+          '@help' => $dvf_helpers->getHelpPageLink('column-overrides'),
         ]) . '</p>',
     ];
 

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -7,6 +7,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\dvf\ConfigurablePluginTrait;
@@ -45,6 +46,13 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
   protected $dvfHelpers;
 
   /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs a new VisualisationStyleBase.
    *
    * @param array $configuration
@@ -59,6 +67,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    *   The module handler.
    * @param \Drupal\dvf\DvfHelpers $dvf_helpers
    *   The DVF helpers.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The Messenger service.
    */
   public function __construct(
     array $configuration,
@@ -66,12 +76,14 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     $plugin_definition,
     VisualisationInterface $visualisation = NULL,
     ModuleHandlerInterface $module_handler,
-    DvfHelpers $dvf_helpers
+    DvfHelpers $dvf_helpers,
+    MessengerInterface $messenger
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->visualisation = $visualisation;
     $this->moduleHandler = $module_handler;
     $this->dvfHelpers = $dvf_helpers;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -104,8 +116,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       $plugin_definition,
       $visualisation,
       $container->get('module_handler'),
-      $container->get('dvf.helpers')
-
+      $container->get('dvf.helpers'),
+      $container->get('messenger')
     );
   }
 

--- a/src/Plugin/Visualisation/VisualisationBase.php
+++ b/src/Plugin/Visualisation/VisualisationBase.php
@@ -81,6 +81,8 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
   protected $entity;
 
   /**
+   * The theme manager.
+   *
    * @var \Drupal\Core\Theme\ThemeManagerInterface
    */
   protected $themeManager;
@@ -100,6 +102,8 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
    *   The style plugin manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   Instance of the module handler.
+   * @param \Drupal\Core\Theme\ThemeManagerInterface $themeManager
+   *   The theme manager.
    */
   public function __construct(
     array $configuration,

--- a/src/Plugin/Visualisation/VisualisationBase.php
+++ b/src/Plugin/Visualisation/VisualisationBase.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\dvf\ConfigurablePluginTrait;
 use Drupal\dvf\Plugin\VisualisationInterface;
 use Drupal\dvf\Plugin\VisualisationSourceManagerInterface;
@@ -80,6 +81,11 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
   protected $entity;
 
   /**
+   * @var \Drupal\Core\Theme\ThemeManagerInterface
+   */
+  protected $themeManager;
+
+  /**
    * Constructs a new VisualisationBase.
    *
    * @param array $configuration
@@ -101,7 +107,8 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
     $plugin_definition,
     VisualisationSourceManagerInterface $source_plugin_manager,
     VisualisationStyleManagerInterface $style_plugin_manager,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    ThemeManagerInterface $themeManager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->sourcePluginManager = $source_plugin_manager;
@@ -110,6 +117,7 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
     $this->style = $configuration['style'];
     $this->moduleHandler = $module_handler;
     $this->entity = isset($configuration['entity']) ? $configuration['entity'] : NULL;
+    $this->themeManager = $themeManager;
   }
 
   /**
@@ -122,7 +130,8 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
       $plugin_definition,
       $container->get('plugin.manager.visualisation.source'),
       $container->get('plugin.manager.visualisation.style'),
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $container->get('theme.manager')
     );
   }
 
@@ -177,8 +186,9 @@ abstract class VisualisationBase extends PluginBase implements VisualisationInte
     if (!isset($this->stylePlugin)) {
       $configuration = $this->getStyleConfiguration();
 
-      // Let other modules alter the style configuration.
+      // Let other modules/themes alter the style configuration.
       $this->moduleHandler->alter('dvf_style_configuration', $configuration['options'], $this);
+      $this->themeManager->alter('dvf_style_configuration', $configuration['options'], $this);
 
       $this->stylePlugin = $this->stylePluginManager->createInstance($configuration['plugin_id'], $configuration['options'], $this);
     }

--- a/src/Plugin/VisualisationInterface.php
+++ b/src/Plugin/VisualisationInterface.php
@@ -2,13 +2,14 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 
 /**
  * Provides an interface defining a Visualisation plugin.
  */
-interface VisualisationInterface extends ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationInterface extends ConfigurableInterface, DependentPluginInterface ,PluginInspectionInterface {
 
   /**
    * Returns the source plugin.

--- a/src/Plugin/VisualisationSourceInterface.php
+++ b/src/Plugin/VisualisationSourceInterface.php
@@ -2,14 +2,15 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides an interface defining a VisualisationSource plugin.
  */
-interface VisualisationSourceInterface extends \Countable, \Iterator, ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationSourceInterface extends \Countable, \Iterator, ConfigurableInterface, DependentPluginInterface, PluginInspectionInterface {
 
   /**
    * Returns a form to configure settings for this plugin.

--- a/src/Plugin/VisualisationSourceInterface.php
+++ b/src/Plugin/VisualisationSourceInterface.php
@@ -49,4 +49,12 @@ interface VisualisationSourceInterface extends \Countable, \Iterator, Configurab
    */
   public function getVisualisation();
 
+  /**
+   * Gets the cache expiry time from the DVF visualisation configuration.
+   *
+   * @return int
+   *   The time the cache object expires.
+   */
+  public function getCacheExpiry();
+
 }

--- a/src/Plugin/VisualisationStyleInterface.php
+++ b/src/Plugin/VisualisationStyleInterface.php
@@ -2,7 +2,8 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -10,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Provides an interface defining a VisualisationStyle plugin.
  */
-interface VisualisationStyleInterface extends ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationStyleInterface extends ConfigurableInterface, DependentPluginInterface, PluginInspectionInterface {
 
   /**
    * Returns a form to configure settings for this plugin.

--- a/src/Plugin/VisualisationStyleInterface.php
+++ b/src/Plugin/VisualisationStyleInterface.php
@@ -4,6 +4,7 @@ namespace Drupal\dvf\Plugin;
 
 use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -39,5 +40,31 @@ interface VisualisationStyleInterface extends ConfigurablePluginInterface, Plugi
    *   Current visualisation instance.
    */
   public function getVisualisation();
+
+  /**
+   * Returns the URI of a DVF file or dataset (JSON|CSV file, or CKAN dataset).
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The Drupal entity that contains the dvf_url or dvf_file.
+   * @param array $dvf_field_types
+   *   An array of field_names that provide dataset(s) for DVF visualisations.
+   *
+   *   E.g. ['dvf_url', 'dvf_file'].
+   *
+   * @return string
+   *   The URI of the file or dataset.
+   */
+  public function getDatasetDownloadUri(EntityInterface $entity, array $dvf_field_types);
+
+  /**
+   * Confirms if a URI or file download link is valid.
+   *
+   * @param string $uri
+   *   The URI to test if valid.
+   *
+   * @return string|bool
+   *   Returns the URI is valid, or false if not.
+   */
+  public function isValidDownloadUri($uri);
 
 }

--- a/src/Plugin/migrate/process/CkanConvertBlob.php
+++ b/src/Plugin/migrate/process/CkanConvertBlob.php
@@ -78,7 +78,7 @@ class CkanConvertBlob extends ProcessPluginBase {
               'tick' => [
                 'rotate' => $ckan_config['axis_settings']['x_tick_rotate'],
                 'width' => $ckan_config['axis_settings']['x_width'],
-                'multiline' => $ckan_config['axis_settings']['x_disable_multiline'],
+                'multiline' => $ckan_config['axis_settings']['x_disable_multiline'] ? FALSE : TRUE,
               ],
             ],
           ],
@@ -104,7 +104,7 @@ class CkanConvertBlob extends ProcessPluginBase {
               'tick' => [
                 'rotate' => $ckan_config['axis_settings']['y_tick_rotate'],
                 'width' => $ckan_config['axis_settings']['y_width'],
-                'multiline' => $ckan_config['axis_settings']['y_disable_multiline'],
+                'multiline' => $ckan_config['axis_settings']['y_disable_multiline'] ? FALSE : TRUE,
               ],
             ],
           ],

--- a/src/Plugin/migrate/process/CkanConvertBlob.php
+++ b/src/Plugin/migrate/process/CkanConvertBlob.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\dvf\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\ProcessPluginBase;
+
+/**
+ * Converts D7 ckan blob settings into D8 settings. Single purpose plugin.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "ckan_convert_blob"
+ * )
+ *
+ * @code
+ * process:
+ *   field_d7_ckan_visualisation/0/options:
+ *     -
+ *       plugin: ckan_convert_blob
+ *       source: ckan_visualisation_d7_configuration
+ * @endcode
+ */
+class CkanConvertBlob extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    if (empty($value)) {
+      return $value;
+    }
+
+    $ckan_values = unserialize($value);
+    $ckan_config = $ckan_values['visualisation_config'];
+
+    $visualisation_style = [
+      'visualisation_style' => 'dvf_' . $ckan_values['visualisation'],
+      'visualisation_style_options' => [
+
+        // Data settings.
+        'data' => [
+          'fields' => count($ckan_config['keys']) ? array_filter($ckan_config['keys']) : [],
+          'field_labels' => $ckan_config['label_settings']['overrides'],
+          'split_field' => $ckan_config['split'],
+          'cache_expiry' => $ckan_config['cache_ttl'],
+          'column_overrides' => $ckan_config['column_overrides'],
+          'data_filters' => [
+            'q' => $ckan_config['ckan_filters']['search'],
+            'filters' => $ckan_config['ckan_filters']['filters'],
+          ],
+        ],
+
+        // Axis settings.
+        'axis' => [
+          'styles' => ['rotated' => $ckan_config['rotated'] === 'true' ? TRUE : FALSE],
+
+          'x' => [
+            'type' => $ckan_config['axis_settings']['x_type'],
+            'label' => ['text' => $ckan_config['x_label']],
+            'x_axis_grouping' => $ckan_config['x_axis_grouping'],
+            'tick' => [
+              'count' => $ckan_config['axis_settings']['x_tick_count'],
+              'culling' => $ckan_config['axis_settings']['x_tick_cull'],
+              'format' => ['timeseries' => $ckan_config['axis_settings']['x_date_format']],
+              'values' => [
+                'field' => $ckan_config['labels'],
+                'custom' => $ckan_config['axis_settings']['x_tick_values'],
+                'indexed' => $ckan_config['axis_settings']['x_tick_value_format'] ?: '',
+              ],
+            ],
+            'styles' => [
+              'padding' => $ckan_config['axis_settings']['x_padding'],
+              'label' => [
+                'position' => 'outer-center',
+              ],
+              'tick' => [
+                'rotate' => $ckan_config['axis_settings']['x_tick_rotate'],
+                'width' => $ckan_config['axis_settings']['x_width'],
+                'multiline' => $ckan_config['axis_settings']['x_disable_multiline'],
+              ],
+            ],
+          ],
+
+          'y' => [
+            'type' => is_null($ckan_config['axis_settings']['y_type']) ? '' : $ckan_config['axis_settings']['y_type'],
+            'label' => ['text' => $ckan_config['y_label']],
+            'tick' => [
+              'count' => $ckan_config['axis_settings']['y_tick_count'],
+              'culling' => $ckan_config['axis_settings']['y_tick_cull'],
+              'format' => ['timeseries' => $ckan_config['axis_settings']['x_date_format']],
+              'values' => [
+                'field' => $ckan_config['labels'],
+                'custom' => $ckan_config['axis_settings']['y_tick_values'],
+                'indexed' => $ckan_config['axis_settings']['y_tick_value_format'] ?: '',
+              ],
+            ],
+            'styles' => [
+              'padding' => $ckan_config['axis_settings']['y_padding'],
+              'label' => [
+                'position' => 'outer-middle',
+              ],
+              'tick' => [
+                'rotate' => $ckan_config['axis_settings']['y_tick_rotate'],
+                'width' => $ckan_config['axis_settings']['y_width'],
+                'multiline' => $ckan_config['axis_settings']['y_disable_multiline'],
+              ],
+            ],
+          ],
+        ],
+
+        // Grid settings.
+        'grid' => [
+          'x' => ['show' => $ckan_config['grid'] === 'x' ? TRUE : FALSE],
+          'y' => ['show' => $ckan_config['grid'] === 'y' ? TRUE : FALSE],
+          'lines' => $ckan_config['grid_lines']['lines'],
+        ],
+
+        // Chart settings.
+        'chart' => [
+          'title' => ['show' => $ckan_config['show_title']],
+          'interaction' => $ckan_config['disable_chart_interaction'] ? FALSE : TRUE,
+          'data' => [
+            'labels' => ['show' => $ckan_config['show_labels']],
+            'legends' => ['interaction' => $ckan_config['disable_legend_interaction'] ? FALSE : TRUE],
+          ],
+          'styles' => [
+            'width' => $ckan_config['chart_size']['width'],
+            'height' => $ckan_config['chart_size']['height'],
+            'padding' => $ckan_config['chart_padding'],
+          ],
+        ],
+      ],
+    ];
+
+    // Individual chart type styles.
+    switch ($ckan_values['visualisation']) {
+      case 'bar_chart':
+        $visualisation_style['visualisation_style_options']['bar_chart']['stacked'] = $ckan_config['stacked'];
+        $visualisation_style['visualisation_style_options']['chart']['data']['stacked'] = $ckan_config['stacked'];
+
+        $visualisation_style['visualisation_style_options']['bar_chart']['data']['order'] = $ckan_config['data_order'];
+        $visualisation_style['visualisation_style_options']['chart']['data']['order'] = $ckan_config['data_order'];
+
+        $visualisation_style['visualisation_style_options']['bar_chart']['bar']['width']['ratio'] = $ckan_config['bar_width'];
+        $visualisation_style['visualisation_style_options']['chart']['width']['ratio'] = $ckan_config['bar_width'];
+
+        $visualisation_style['visualisation_style_options']['bar_chart']['bar']['width']['value'] = $ckan_config['bar_width_override'];
+        $visualisation_style['visualisation_style_options']['chart']['width']['value'] = $ckan_config['bar_width_override'];
+
+        break;
+
+      case 'line_chart':
+        $visualisation_style['visualisation_style_options']['chart']['data']['type'] = $ckan_config['area'] ? 'area' : $visualisation_style['chart']['data']['type'];
+        $visualisation_style['visualisation_style_options']['line_chart']['area']['enabled'] = $ckan_config['area'] ? TRUE : FALSE;
+
+        $visualisation_style['visualisation_style_options']['point']['show'] = $ckan_config['hide_points'] ? FALSE : TRUE;
+        $visualisation_style['visualisation_style_options']['line_chart']['data']['points']['show'] = $ckan_config['hide_points'] ? FALSE : TRUE;
+        break;
+
+      case 'scatter_plot_chart':
+        $visualisation_style['visualisation_style_options']['scatter_plot_chart']['point']['size'] = $ckan_config['point_size'];
+        $visualisation_style['visualisation_style_options']['point']['radius'] = $ckan_config['point_size'];
+        break;
+
+      case 'spline_chart':
+        $visualisation_style['visualisation_style_options']['point']['show'] = $ckan_config['hide_points'] ? FALSE : TRUE;
+        $visualisation_style['visualisation_style_options']['spline_chart']['data']['points']['show'] = $ckan_config['hide_points'] ? FALSE : TRUE;
+        break;
+    }
+
+    return $visualisation_style;
+
+  }
+
+}

--- a/src/Plugin/migrate/process/CkanConvertUrl.php
+++ b/src/Plugin/migrate/process/CkanConvertUrl.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\dvf\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\ProcessPluginBase;
+
+/**
+ * Converts a D7 ckan url. This is a single purpose plugin.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "ckan_convert_url"
+ * )
+ *
+ * @code
+ * process:
+ *   field_d7_ckan_visualisation/0/uri:
+ *     -
+ *       plugin: ckan_convert_url
+ *       source: ckan_visualisation_d7_uri
+ * @endcode
+ */
+class CkanConvertUrl extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $ckan_url = 'https://data.gov.au/dataset/{ID_1}/resource/{ID_2}';
+    $url_parts = explode('/', $value);
+
+    if (!empty($url_parts[3]) && !empty($url_parts[4])) {
+      $ckan_url = str_replace('{ID_1}', $url_parts[3], $ckan_url);
+      $ckan_url = str_replace('{ID_2}', $url_parts[4], $ckan_url);
+    }
+    else {
+      $ckan_url = '';
+    }
+
+    return $ckan_url;
+  }
+
+}

--- a/src/Plugin/migrate/source/CkanEntityMigration.php
+++ b/src/Plugin/migrate/source/CkanEntityMigration.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\dvf\Plugin\migrate\source;
+
+use Drupal\migrate\Row;
+use Drupal\migrate_drupal\Plugin\migrate\source\d7\FieldableEntity;
+
+/**
+ * Drupal 7 managed CKAN source from database.
+ *
+ * @MigrateSource(
+ *   id = "d7_ckan_entity_migration",
+ *   source_module = "file_entity"
+ * )
+ *
+ * @code
+ * source:
+ *   plugin: d7_ckan_entity_migration
+ *   constants:
+ *     source_type: ckan
+ * @endcode
+ */
+class CkanEntityMigration extends FieldableEntity {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = $this->select('file_managed', 'fm')
+      ->fields('fm', [
+        'fid',
+        'filename',
+        'type',
+        'uid',
+        'uri',
+      ])
+      ->fields('fd', [
+        'ckan_visualisation_config',
+      ]);
+
+    $query->leftJoin('field_data_ckan_visualisation', 'fd', 'fm.fid = fd.entity_id');
+
+    if (isset($this->configuration['constants']['source_type'])) {
+      $query->condition('fm.type', $this->configuration['constants']['source_type']);
+    }
+
+    return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    $fields = [
+      'fid' => $this->t('File Id.'),
+      'filename' => $this->t('File label.'),
+      'type' => $this->t('File type.'),
+      'uid' => $this->t('The user that uploaded the file.'),
+      'uri' => $this->t('The uri of the CKAN entity.'),
+      'ckan_visualisation_config' => $this->t('The CKAN visualisation config.'),
+    ];
+
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    $ids['fid']['type'] = 'integer';
+
+    return $ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+
+    $fid = $row->getSourceProperty('fid');
+    $type = $row->getSourceProperty('type');
+
+    $entity_fields = $this->getFields('file', $type);
+
+    foreach ($entity_fields as $field_name => $field) {
+      $value = $this->getFieldValues('file', $field_name, $fid);
+      $row->setSourceProperty($field_name, $value);
+    }
+
+    return parent::prepareRow($row);
+  }
+
+}

--- a/templates/help-page.html.twig
+++ b/templates/help-page.html.twig
@@ -1,0 +1,5 @@
+{% if topic is not empty %}
+  {% include '@dvf/help/' ~ topic ~ '.html.twig' %}
+{% else %}
+  <p>DVF help page not found. Please check the URL and try again.</p>
+{% endif %}

--- a/templates/help/column-overrides.html.twig
+++ b/templates/help/column-overrides.html.twig
@@ -1,0 +1,55 @@
+<h2>Column/Group overrides</h2>
+
+<p>Column overrides allow you to change the style of a specific data column group. This can be useful for combining
+    different graph styles eg. lines and bars, overriding a colour, changing the order or applying a class so further
+    styling options can be defined in css.</p>
+
+<p>There is a text area for each column and you can add multiple settings per column. Add each setting on a new
+    line and separate setting name and value with a pipe (|). Eg.</p>
+
+<pre>
+type|line
+color|#cccccc
+weight|20
+legend|hide
+</pre>
+
+<h3>Available overrides</h3>
+
+<h4>type</h4>
+
+<p>Eg. If your graph is bar chart, you could use this to set one of the columns to be a line for something
+    like an average, or representing data that is slightly different than the rest.</p>
+
+<p><strong>Available options:</strong> line, spline, bar, area, area-spline or scatter</p>
+
+<h4>color</h4>
+
+<p>Override the colour on a specific column. Use a <a href="http://www.color-hex.com/" target="_blank">hex value</a>.
+    Eg. #000000 = black.</p>
+
+<h4>legend</h4>
+
+<p>Hide the legend for a specific column. This only has one option <em>hide</em>.</p>
+
+<h4>weight</h4>
+
+<p>Weighting (ordering) allows you to change the position of column/groups without having to update the
+    source dataset. Heaver items sink to the end of lists, lighter items float to the top.</p>
+
+<p>If you wanted an column to appear first, you could set a really low weight of <strong>-50</strong>.
+    Alternatively if you wanted a column to appear last you could set a high weight of <strong>50</strong>.
+    Any positive or negative integer is valid.</p>
+
+<h4>style</h4>
+
+<p>This currently only applies to line graphs and it allows you to set the line to be <strong>dashed</strong>.</p>
+
+<h4>class</h4>
+
+<p>Adding a css class to a column allows additional custom styling. Currently there is one 'out of the box' style
+    available <strong>hide-points</strong> that hide the points for a specific column.</p>
+
+<p>You can add any classes you like and then define those styles is your custom css.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/data-filters.html.twig
+++ b/templates/help/data-filters.html.twig
@@ -1,0 +1,18 @@
+<h2>CKAN Filters</h2>
+
+<p>Filters can be used to refine/reduce the records returned from the CKAN datasource.</p>
+
+<h3>Full text query</h3>
+
+<p>This limits the results to records that contain a certain keyword or value.</p>
+
+<h3>Filters</h3>
+
+<p>This limits the results to records that match certain conditions. Eg. {"year":"2016"}.
+Format should be JSON and multiple filters can be applied at once.</p>
+
+<h3>Caution</h3>
+
+<p>As results get heavily cached, you may need to clear caches for these filters to take effect.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/grid-lines.html.twig
+++ b/templates/help/grid-lines.html.twig
@@ -1,0 +1,30 @@
+<h2>Grid/Trend lines</h2>
+
+<p>Add additional grid lines to the chart either on the X or Y Axis. You can add as many additional lines as you
+    like.</p>
+
+<p>Additional grid lines can have a label and are useful for such things as trend lines or intersects.</p>
+
+<h3>For each grid line</h3>
+
+<h4>Axis</h4>
+
+<p>Y axis will add a horizontal line at the value defined. X axis will add a vertical line.</p>
+
+<h4>Value</h4>
+
+<p>This defines where the line will be added. The value must be within the dataset.</p>
+
+<h4>Label</h4>
+
+<p>Add an optional label to identify what the line represents. Eg average, min or max.</p>
+
+<h4>Label position</h4>
+
+<p>Define where the label appears on the line. Start, middle or end. On a X line start is the bottom, end is the top.</p>
+
+<h3>Adding and removing lines</h3>
+
+<p>Clicking 'Add line' will add a new empty line. Clicking 'Remove line' will remove the last line in the list.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/keys.html.twig
+++ b/templates/help/keys.html.twig
@@ -1,0 +1,43 @@
+<h2>Keys</h2>
+
+<p>This is the data that gets included in the visualisation. What data to include in the visualisation.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p>The available keys would be <strong>Size, Red, Green</strong> and <strong>Blue</strong> and using the keys selection, you
+    could limit it to only show <strong>Green</strong> and <strong>Blue</strong> data in the visualisation.</p>
+
+<h3>Caution</h3>
+
+<p>For best results, do not include the key used in "X axis settings > Tick values field" as this will create a duplicate column.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/label-key.html.twig
+++ b/templates/help/label-key.html.twig
@@ -1,0 +1,44 @@
+<h2>Label Key</h2>
+
+<p>What key contains the labels. The value of each label key will be the X tick values if group by keys
+or the legend if group by labels.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p>The label key would be <strong>Size</strong></p>
+
+<h3>Caution</h3>
+
+<p>Ensure the label key is not also selected in "Keys" as it will cause duplicate columns and
+break some visualisations.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/label-overrides.html.twig
+++ b/templates/help/label-overrides.html.twig
@@ -1,0 +1,25 @@
+<h2>Label overrides</h2>
+
+<p>The labels in the dataset may not represent what you want to display on the site. This is most often due
+  to CKAN not allowing certain characters eg spaces or symbols.</p>
+
+<p>Label overrides allow you to do label replacements so when a label is displayed in a visualisation you can
+    improve the presentation or add additional information.</p>
+
+<p>Symbols may be used in replacements. Html code is not supported.</p>
+
+<p>Add one label override per line and separate original label and new label with a pipe (|). Eg.</p>
+
+<pre>
+MyOriginalLabel1|My nicely formatted label
+MyOtherOriginalLabel|My Awesome label
+</pre>
+
+<p>Label replacements apply to both column groups (the legend) and X axis tick values. They do <u>not</u> apply to Y
+   axis values.</p>
+
+<h3>Caution</h3>
+
+<p>All label values must be unique.</p>
+
+<p>&nbsp;</p>

--- a/templates/help/split.html.twig
+++ b/templates/help/split.html.twig
@@ -1,0 +1,114 @@
+<h2>Split field</h2>
+
+<p>Optionally spit into multiple visualisations based on the value of this key.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2010</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2015</td>
+        <td>12</td>
+        <td>17</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2010</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2015</td>
+        <td>32</td>
+        <td>37</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2010</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2015</td>
+        <td>62</td>
+        <td>72</td>
+    </tr>
+</table>
+
+<p>If you split on the <strong>Year</strong> field, you would get 2 graphs/tables that look like this:</p>
+
+<h4>2010</h4>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2010</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2010</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2010</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<h4>2015</h4>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Year</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>2015</td>
+        <td>12</td>
+        <td>17</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>2015</td>
+        <td>32</td>
+        <td>37</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>2015</td>
+        <td>62</td>
+        <td>72</td>
+    </tr>
+</table>
+
+<p>&nbsp;</p>

--- a/templates/help/x-axis-grouping.html.twig
+++ b/templates/help/x-axis-grouping.html.twig
@@ -1,0 +1,69 @@
+<h2>X Axis Grouping</h2>
+
+<p>X Grouping allows you to flip how the data is displayed. The default "Group by Keys" will render the table
+matching the original source and in a graph the Keys will form the legend. If "Group by Labels" is used, the
+keys and labels gets swapped and in a graph the labels will form the legend.</p>
+
+<h3>Example</h3>
+
+<p>In this example dataset:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Red</th>
+        <th>Green</th>
+        <th>Blue</th>
+    </tr>
+    <tr>
+        <th>Small</th>
+        <td>5</td>
+        <td>10</td>
+        <td>15</td>
+    </tr>
+    <tr>
+        <th>Medium</th>
+        <td>25</td>
+        <td>30</td>
+        <td>35</td>
+    </tr>
+    <tr>
+        <th>Large</th>
+        <td>50</td>
+        <td>60</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p><strong>Group by keys</strong> would result in the same table being outputted.</p>
+
+<p>If you were to use <strong>Group by labels</strong> the rendered table would look like this:</p>
+
+<table>
+    <tr>
+        <th>Size</th>
+        <th>Small</th>
+        <th>Medium</th>
+        <th>Large</th>
+    </tr>
+    <tr>
+        <th>Red</th>
+        <td>5</td>
+        <td>25</td>
+        <td>50</td>
+    </tr>
+    <tr>
+        <th>Green</th>
+        <td>10</td>
+        <td>30</td>
+        <td>60</td>
+    </tr>
+    <tr>
+        <th>Blue</th>
+        <td>15</td>
+        <td>35</td>
+        <td>70</td>
+    </tr>
+</table>
+
+<p>&nbsp;</p>


### PR DESCRIPTION
### Replace deprecated methods with those compatible with Drupal 9:

- Drupal\Component\Plugin\ConfigurablePluginInterface is deprecated in Drupal 8.7.0 and will be removed before Drupal 9.0.0. Replaced with  ConfigurableInterface and DependentPluginInterface

### Add the new key
- The core version requirement key in info.yml