### PR TITLE
Added heading when visualisation is split based on a field value

### DIFF
--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -743,6 +743,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       $build[$group_key]['chart'] = [
         '#type' => 'container',
         '#attributes' => ['class' => ['dvf-chart']],
+        'heading' => $this->buildSplitHeading($group_key),
         'content' => $this->buildChart($group_records),
       ];
 

--- a/src/Plugin/Visualisation/Style/Table.php
+++ b/src/Plugin/Visualisation/Style/Table.php
@@ -96,6 +96,7 @@ class Table extends TableVisualisationStyleBase {
       $build[$group_key]['table'] = [
         '#type' => 'container',
         '#attributes' => ['class' => ['dvf-table']],
+        'heading' => $this->buildSplitHeading($group_key),
         'content' => $this->buildTable($group_records),
       ];
     }

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -517,4 +517,26 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
     return FALSE;
   }
 
+  /**
+   * Return markup for a split field heading.
+   *
+   * @param string $label
+   *   Label for the heading.
+   *
+   * @return array
+   *   A heading tag for the label, if label is "all" (ungrouped), return empty.
+   */
+  public function buildSplitHeading($label) {
+    if ('all' === $label) {
+      return [];
+    }
+
+    return [
+      '#type' => 'html_tag',
+      '#tag' => 'h3',
+      '#value' => htmlentities($label),
+      '#attributes' => ['class' => 'dvf-split-heading'],
+    ];
+  }
+
 }


### PR DESCRIPTION
When a split field is used, there is no way to identify each visualisation, (the split value is never displayed). 

This prepends a heading to visualisations when they are split.

