### PR TITLE
Fix the module compatibility issue for upgrading from Drupal 8 to Drupal 9

### DIFF
--- a/dvf.info.yml
+++ b/dvf.info.yml
@@ -3,3 +3,4 @@ description: 'Data Visualisation Framework makes it easy to generate visualisati
 type: module
 package: Data Visualisation Framework
 core: 8.x
+core_version_requirement: ^8 || ^9

--- a/dvf_ckan/dvf_ckan.info.yml
+++ b/dvf_ckan/dvf_ckan.info.yml
@@ -3,6 +3,7 @@ description: 'CKAN integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - ckan_connect:ckan_connect
   - dvf:dvf

--- a/dvf_csv/dvf_csv.info.yml
+++ b/dvf_csv/dvf_csv.info.yml
@@ -3,5 +3,6 @@ description: 'CSV integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - dvf:dvf

--- a/dvf_json/dvf_json.info.yml
+++ b/dvf_json/dvf_json.info.yml
@@ -3,5 +3,6 @@ description: 'JSON integration for the Data Visualisation Framework module.'
 type: module
 package: Data Visualisation Framework
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - dvf:dvf

--- a/src/Plugin/VisualisationInterface.php
+++ b/src/Plugin/VisualisationInterface.php
@@ -2,13 +2,14 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 
 /**
  * Provides an interface defining a Visualisation plugin.
  */
-interface VisualisationInterface extends ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationInterface extends ConfigurableInterface, DependentPluginInterface, PluginInspectionInterface {
 
   /**
    * Returns the source plugin.

--- a/src/Plugin/VisualisationSourceInterface.php
+++ b/src/Plugin/VisualisationSourceInterface.php
@@ -2,14 +2,15 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides an interface defining a VisualisationSource plugin.
  */
-interface VisualisationSourceInterface extends \Countable, \Iterator, ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationSourceInterface extends \Countable, \Iterator, ConfigurableInterface, DependentPluginInterface, PluginInspectionInterface {
 
   /**
    * Returns a form to configure settings for this plugin.

--- a/src/Plugin/VisualisationStyleInterface.php
+++ b/src/Plugin/VisualisationStyleInterface.php
@@ -2,7 +2,8 @@
 
 namespace Drupal\dvf\Plugin;
 
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -10,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Provides an interface defining a VisualisationStyle plugin.
  */
-interface VisualisationStyleInterface extends ConfigurablePluginInterface, PluginInspectionInterface {
+interface VisualisationStyleInterface extends ConfigurableInterface, DependentPluginInterface, PluginInspectionInterface {
 
   /**
    * Returns a form to configure settings for this plugin.


### PR DESCRIPTION
Remove the deprecated functions and replace with the one which is compatible with Drupal 9, add key core_version_requirement to *.info.yml file