### PR TITLE
Get file contents via uri rather than url

### DIFF
--- a/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
+++ b/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
@@ -8,7 +8,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dvf\Plugin\VisualisationInterface;
 use Drupal\dvf\Plugin\Visualisation\Source\VisualisationSourceBase;
-use GuzzleHttp\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,13 +31,6 @@ class CsvFile extends VisualisationSourceBase implements ContainerFactoryPluginI
    * @var \Drupal\Core\Cache\CacheBackendInterface
    */
   protected $cache;
-
-  /**
-   * The HTTP client.
-   *
-   * @var \GuzzleHttp\Client
-   */
-  protected $httpClient;
 
   /**
    * The CSV file fields.
@@ -69,13 +61,10 @@ class CsvFile extends VisualisationSourceBase implements ContainerFactoryPluginI
    *   The module handler.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend.
-   * @param \GuzzleHttp\Client $http_client
-   *   The HTTP client.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, VisualisationInterface $visualisation = NULL, ModuleHandlerInterface $module_handler, CacheBackendInterface $cache, Client $http_client) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, VisualisationInterface $visualisation = NULL, ModuleHandlerInterface $module_handler, CacheBackendInterface $cache) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $visualisation, $module_handler);
     $this->cache = $cache;
-    $this->httpClient = $http_client;
   }
 
   /**
@@ -102,8 +91,7 @@ class CsvFile extends VisualisationSourceBase implements ContainerFactoryPluginI
       $plugin_definition,
       $visualisation,
       $container->get('module_handler'),
-      $container->get('cache.dvf_csv'),
-      $container->get('http_client')
+      $container->get('cache.dvf_csv')
     );
   }
 

--- a/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
+++ b/dvf_csv/src/Plugin/Visualisation/Source/CsvFile.php
@@ -239,7 +239,7 @@ class CsvFile extends VisualisationSourceBase implements ContainerFactoryPluginI
   protected function fetchData() {
     try {
       $uri = $this->config('uri');
-      $response = $this->httpClient->get($uri)->getBody()->getContents();
+      $response = file_get_contents($uri);
     }
     catch (\Exception $e) {
       $response = NULL;

--- a/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
+++ b/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
@@ -211,7 +211,7 @@ class JsonFile extends VisualisationSourceBase implements ContainerFactoryPlugin
   protected function fetchData() {
     try {
       $uri = $this->config('uri');
-      $response = $this->httpClient->get($uri)->getBody()->getContents();
+      $response = file_get_contents($uri);
     }
     catch (\Exception $e) {
       $response = NULL;

--- a/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
+++ b/dvf_json/src/Plugin/Visualisation/Source/JsonFile.php
@@ -9,7 +9,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\dvf\Plugin\VisualisationInterface;
 use Drupal\dvf\Plugin\Visualisation\Source\VisualisationSourceBase;
 use Flow\JSONPath\JSONPath;
-use GuzzleHttp\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -33,13 +32,6 @@ class JsonFile extends VisualisationSourceBase implements ContainerFactoryPlugin
    * @var \Drupal\Core\Cache\CacheBackendInterface
    */
   protected $cache;
-
-  /**
-   * The HTTP client.
-   *
-   * @var \GuzzleHttp\Client
-   */
-  protected $httpClient;
 
   /**
    * The JSON file fields.
@@ -70,13 +62,10 @@ class JsonFile extends VisualisationSourceBase implements ContainerFactoryPlugin
    *   The module handler.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache backend.
-   * @param \GuzzleHttp\Client $http_client
-   *   The HTTP client.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, VisualisationInterface $visualisation = NULL, ModuleHandlerInterface $module_handler, CacheBackendInterface $cache, Client $http_client) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, VisualisationInterface $visualisation = NULL, ModuleHandlerInterface $module_handler, CacheBackendInterface $cache) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $visualisation, $module_handler);
     $this->cache = $cache;
-    $this->httpClient = $http_client;
   }
 
   /**
@@ -103,8 +92,7 @@ class JsonFile extends VisualisationSourceBase implements ContainerFactoryPlugin
       $plugin_definition,
       $visualisation,
       $container->get('module_handler'),
-      $container->get('cache.dvf_json'),
-      $container->get('http_client')
+      $container->get('cache.dvf_json')
     );
   }
 

--- a/src/Plugin/Field/FieldType/VisualisationFileItem.php
+++ b/src/Plugin/Field/FieldType/VisualisationFileItem.php
@@ -129,7 +129,7 @@ class VisualisationFileItem extends FileItem implements VisualisationItemInterfa
 
     $file = File::load($fid);
 
-    return !empty($file) ? file_create_url($file->getFileUri()) : NULL;
+    return !empty($file) ? $file->getFileUri() : NULL;
   }
 
 }


### PR DESCRIPTION
This retrieves file contents (used by dvf_csv and dvf_json) via URI rather than URL which was causing issues when using docker stack. This also should solve some other minor bugs with settings widgets 