### PR TITLE
Fix ajax widget callback for x-axis settings

### DIFF
--- a/src/FormElementAttributesTrait.php
+++ b/src/FormElementAttributesTrait.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\dvf;
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Provides methods to manipulate form elements.
  */
@@ -44,6 +46,20 @@ trait FormElementAttributesTrait {
     $selector = $tag . '[name="' . $name . '"]';
 
     return $selector;
+  }
+
+  /**
+   * Get the correct parent field name within a ajax callback.
+   *
+   * @param  \Drupal\Core\Form\FormStateInterface  $form_state
+   *   Form state passed in ajax callback.
+   *
+   * @return string
+   *   The parent field name for the triggering element.
+   */
+  protected static function formElementCallbackParentName(FormStateInterface $form_state) {
+    $trigger = $form_state->getTriggeringElement();
+    return $trigger['#parents'][0];
   }
 
 }

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -715,7 +715,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    *   The updated form element.
    */
   public function updateColumnOverrides(array $form, FormStateInterface $form_state) {
-    return $form['field_visualisation_url']['widget'][0]['options']['visualisation_style_options']['data']['column_overrides'];
+    $field_name = self::formElementCallbackParentName($form_state);
+    return $form[$field_name]['widget'][0]['options']['visualisation_style_options']['data']['column_overrides'];
   }
 
   /**
@@ -730,7 +731,8 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    *   The updated form element.
    */
   public function updateAxisGrouping(array $form, FormStateInterface $form_state) {
-    return $form['field_visualisation_url']['widget'][0]['options']['visualisation_style_options']['axis']['x']['x_axis_grouping'];
+    $field_name = self::formElementCallbackParentName($form_state);
+    return $form[$field_name]['widget'][0]['options']['visualisation_style_options']['axis']['x']['x_axis_grouping'];
   }
 
   /**


### PR DESCRIPTION
Code assumed field name was 'field_visualisation_url' where this could be anything defined by the site builder. Added method to correctly determine parent field name and use that in ajax callbacks