### PR TITLE
#DVFD9-22 Update C3 and D3 library, The latest version for C3 and D3 …

### DIFF
--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -1,25 +1,25 @@
 c3:
   remote: https://github.com/c3js/c3
-  version: "0.7.1"
+  version: "0.7.8"
   license:
     name: MIT
     url: https://github.com/c3js/c3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.8/c3.min.js: { type: external, minified: true }
   css:
     component:
-      https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.css: { type: external, minified: true }
+      https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.8/c3.min.css: { type: external, minified: true }
 
 d3:
   remote: https://github.com/d3/d3
-  version: "5.5.0"
+  version: "5.16.0"
   license:
     name: BSD-3
     url: https://github.com/d3/d3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/d3/5.5.0/d3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.min.js: { type: external, minified: true }
 
 datatables:
   remote: https://github.com/DataTables/DataTables


### PR DESCRIPTION
The latest version for C3 and D3 are 0.7.20 and 7.0.0 respectively, but the graph cannot be generated using the latest library. 

The top version for C3 and D3 which can still make the diagram works are 0.7.8 and 5.16.0 respectively. 