### PR TITLE
#DVFD9-46 and #DVFD9-42 Fix Remove Show table button and Duplicate Data Shown on the Bar Chart

### DIFF
--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -111,6 +111,14 @@
         return this;
       }
 
+      $('<button/>')
+        .html('Show table')
+        .addClass('table-chart--toggle')
+        .click(self.toggleView.bind(self))
+        .appendTo($buttonWrapper);
+
+      $buttonWrapper.addClass(processedClass);
+
       // Set download data click listener.
       if ($(this.element).is('table')) {
         $('.download-data', $(this.element).closest('.dvf-table')).on('click', function() {

--- a/js/jquery.dvfTables.js
+++ b/js/jquery.dvfTables.js
@@ -111,14 +111,6 @@
         return this;
       }
 
-      $('<button/>')
-        .html('Show table')
-        .addClass('table-chart--toggle')
-        .click(self.toggleView.bind(self))
-        .appendTo($buttonWrapper);
-
-      $buttonWrapper.addClass(processedClass);
-
       // Set download data click listener.
       if ($(this.element).is('table')) {
         $('.download-data', $(this.element).closest('.dvf-table')).on('click', function() {

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -365,7 +365,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    *   The fields.
    */
   protected function fields() {
-    return array_unique(array_filter($this->config('data','fields')));
+    return array_unique(array_filter($this->config('data', 'fields')));
   }
 
   /**

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -365,7 +365,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    *   The fields.
    */
   protected function fields() {
-    return array_filter($this->config('data', 'fields'));
+    return array_unique(array_filter($this->config('data','fields')));
   }
 
   /**
@@ -375,7 +375,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    *   The field labels.
    */
   protected function fieldLabels() {
-    $labels = array_intersect_key($this->getSourceFieldOptions(), $this->fields());
+    $labels = array_intersect(array_values($this->getSourceFieldOptions()), $this->fields());
 
     $label_overrides = $this->config('data', 'field_labels');
     $label_overrides = preg_split('/\r\n|[\r\n]/', $label_overrides);


### PR DESCRIPTION
Remove Show Table button, since it's not working due to the missing header field for the table when showing as a bar chart