### PR TITLE
Move from C3js to billboard.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Visualisation Framework. This suite of modules deliver greater customisability
 and control, increasing the number of the data types consumed by the module,
 and providing more accessibility for developers.
 
-Now included are the popular, industry-standard, JavaScript libraries: C3.js,
+Now included are the popular, industry-standard, JavaScript libraries: billboard.js,
 based on D3 (for charting), and DataTables (for out-of-the-box table styling).
 We have also updated the module to allow for more customisable visualisation
 placement using fields.

--- a/dvf.libraries.yml
+++ b/dvf.libraries.yml
@@ -1,25 +1,25 @@
-c3:
-  remote: https://github.com/c3js/c3
-  version: "0.7.1"
+billboard:
+  remote: https://github.com/naver/billboard.js
+  version: "3.0.3"
   license:
     name: MIT
-    url: https://github.com/c3js/c3/blob/master/LICENSE
+    url: https://github.com/naver/billboard.js/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/billboard.js/3.0.3/billboard.min.js: { type: external, minified: true }
   css:
     component:
-      https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.1/c3.min.css: { type: external, minified: true }
+      https://cdnjs.cloudflare.com/ajax/libs/billboard.js/3.0.3/billboard.min.css: { type: external, minified: true }
 
 d3:
   remote: https://github.com/d3/d3
-  version: "5.5.0"
+  version: "6.7.0"
   license:
     name: BSD-3
     url: https://github.com/d3/d3/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdnjs.cloudflare.com/ajax/libs/d3/5.5.0/d3.min.js: { type: external, minified: true }
+    https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js: { type: external, minified: true }
 
 datatables:
   remote: https://github.com/DataTables/DataTables
@@ -53,7 +53,7 @@ jquery.dvfCharts:
     - core/drupal
     - core/drupalSettings
     - dvf/d3
-    - dvf/c3
+    - dvf/billboard
     - dvf/filesaver
 
 dvfCharts:

--- a/js/jquery.chart_export.js
+++ b/js/jquery.chart_export.js
@@ -47,11 +47,11 @@
       // Export as png dimensions. When values are empty, will automatically size.
       width: '',
       height: '',
-      // Embed additional styles in svg (fixes display bugs with c3js charts)
+      // Embed additional styles in svg (fixes display bugs with billboard.js charts)
       includeExportStyles: true,
       exportStylesheets: [],
       // If an export stylesheet is provided, these styles get replaced with the stylesheet content.
-      exportStyles: 'svg{font:10px sans-serif}line,path{fill:none;stroke:#000}.c3-bar{stroke:none!important}',
+      exportStyles: 'svg{font:10px sans-serif}line,path{fill:none;stroke:#000}.bb-bar{stroke:none!important}',
       // Passed Validation requirements.
       valid: true,
       // Error message.
@@ -62,7 +62,7 @@
       ieDownloadMessage: 'Right click the graph and select "Save picture as" then in the save dialog, set the ' +
         '"Save as type" to '
     };
-    
+
     // Update defaults with passed settings.
     self.settings = $.extend(self.defaults, settings);
 
@@ -120,7 +120,7 @@
       // Add font family to texts.
       self.settings.svg.find('text').attr('font-family', '\'arial\'');
 
-      // Include c3js styles.
+      // Include billboard.js styles.
       self.includeExportStyles();
 
       // Return self for chaining.
@@ -128,7 +128,7 @@
     };
 
     /*
-     * Inject c3js styles if required.
+     * Inject billboard.js styles if required.
      */
     self.includeExportStyles = function () {
       // Check if styles need to be added first.
@@ -184,7 +184,7 @@
     // Embed current export styles.
     self.embedStyles = function () {
       // Create a style element.
-      self.$c3styles = $('<style>')
+      self.$chartStyles = $('<style>')
         .attr('type', 'text/css')
         .html("<![CDATA[\n" + self.settings.exportStyles + "\n]]>")
         .appendTo($('defs', self.settings.svg));

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -299,7 +299,7 @@
       point.show = !!pointShow;
 
       if (pointRadius) {
-        point.r = pointRadius;
+        point.r = parseFloat(pointRadius);
       }
 
       this.config.point = $.isEmptyObject(point) ? null : point;

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -1,4 +1,4 @@
-;(function ($, c3) {
+;(function ($, bb) {
 
   'use strict';
 
@@ -40,12 +40,12 @@
     },
 
     /**
-     * Calls the C3 third party plugin with the parsed config.
+     * Calls the billboard third party plugin with the parsed config.
      *
      * @returns {Plugin}
      */
     generateChart: function () {
-      c3.generate(this.config);
+      bb.generate(this.config);
       return this;
     },
 
@@ -331,10 +331,10 @@
     },
 
     /**
-     * Parse user settings into object suitable for use with C3 Gauge Chart.
+     * Parse user settings into object suitable for use with bb Gauge Chart.
      *
-     * @example https://c3js.org/samples/chart_gauge.html
-     * @see https://c3js.org/reference.html#gauge-label-show
+     * @example https://bbjs.org/samples/chart_gauge.html
+     * @see https://bbjs.org/reference.html#gauge-label-show
      *
      * @returns {Plugin}
      */
@@ -568,4 +568,4 @@
     });
   };
 
-})(jQuery, c3);
+})(jQuery, bb);

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -333,8 +333,8 @@
     /**
      * Parse user settings into object suitable for use with bb Gauge Chart.
      *
-     * @example https://bbjs.org/samples/chart_gauge.html
-     * @see https://bbjs.org/reference.html#gauge-label-show
+     * @example https://naver.github.io/billboard.js/demo/#Chart.GaugeChart
+     * @see https://naver.github.io/billboard.js/release/latest/doc/Options.html#.gauge
      *
      * @returns {Plugin}
      */

--- a/src/Plugin/Visualisation/Style/ScatterPlotChart.php
+++ b/src/Plugin/Visualisation/Style/ScatterPlotChart.php
@@ -57,6 +57,7 @@ class ScatterPlotChart extends AxisChart {
     $settings = parent::chartBuildSettings($records);
 
     $settings['chart']['data']['type'] = 'scatter';
+    $settings['point']['show'] = TRUE;
     $settings['point']['radius'] = $this->config('scatter_plot_chart', 'point', 'size');
 
     return $settings;


### PR DESCRIPTION
As C3 is deprecated, this moves chart library to billboard.js which has replaced it. Regression tested all chart types and the only one that had a minor issue was scatterplot and this was likely due a bug in C3 rather than billboard.

This enables us to move to the (almost) latest D3 `v6.7` and take advantage of a larger catalogue of chart types, yay!