### PR TITLE
#DVFD9-45 Hide the Page Title and Update the Field Description

### DIFF
--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -83,11 +83,6 @@
         };
       }
 
-      // Display chart title is title.show is true.
-      if (plugin.options.chart.title.show) {
-        this.config.title = { text: plugin.options.chart.title.text };
-      }
-
       return this;
     },
 

--- a/js/jquery.dvfCharts.js
+++ b/js/jquery.dvfCharts.js
@@ -83,6 +83,11 @@
         };
       }
 
+      // Display chart title is title.show is true.
+      if (plugin.options.chart.title.show) {
+        this.config.title = { text: plugin.options.chart.title.text };
+      }
+
       return this;
     },
 

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -551,7 +551,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     $form['chart']['title']['text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Chart title'),
-      '#description' => $this->t('Optional title for admin purposes only, not displayed on the frontend'),
+      '#description' => $this->t('NOTE: if this is used with a split chart, the same title will display on each chart'),
       '#default_value' => $this->config('chart', 'title', 'text'),
     ];
 

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -551,7 +551,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
     $form['chart']['title']['text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Chart title'),
-      '#description' => $this->t('Title to display on the chart, this gets included when download as SVG or PNG is selected'),
+      '#description' => $this->t('Optional title for admin purposes only, not displayed on the frontend'),
       '#default_value' => $this->config('chart', 'title', 'text'),
     ];
 


### PR DESCRIPTION
Hide the Page Title for the charts no matter whether the graph is split or not; Update the Field Description as “Optional title for admin purposes only, not displayed on the frontend”