### PR TITLE
Fix for column overrides not working when field keys are numbers

### DIFF
--- a/src/DvfHelpers.php
+++ b/src/DvfHelpers.php
@@ -90,4 +90,29 @@ class DvfHelpers {
     return $array;
   }
 
+  /**
+   * Helper to transform a config string to an associative array.
+   *
+   * @param string $config_string
+   *   A string, generally from a textarea input. Each line becomes an array
+   *   item, on each line, key/value are separated with a pipe (|).
+   *
+   * @return array
+   *   Associative array
+   */
+  public function configStringToArray(string $config_string) {
+    $array = [];
+    if (empty(trim($config_string))) {
+      return $array;
+    }
+
+    $items = preg_split("(\r\n?|\n)", $config_string);
+    foreach ($items as $item) {
+      [$key, $value] = explode('|', trim($item),2);
+      $array[$key] = $value;
+    }
+
+    return $array;
+  }
+
 }

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -913,15 +913,6 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    *   An array of column override settings.
    */
   protected function getColumnOverrides() {
-    $allowed_overrides = [
-      'color',
-      'type',
-      'legend',
-      'style',
-      'weight',
-      'class',
-    ];
-
     $column_overrides = array_fill_keys($this->fieldLabelsOriginal(), []);
 
     foreach ($this->config('data', 'column_overrides') as $field_name => $column_override) {
@@ -933,8 +924,7 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       $column_overrides[$real_field_name] = $this->dvfHelpers->configStringToArray($column_override);
     }
 
-    $sorted = $this->setArrayOrder($column_overrides);
-    return $sorted;
+    return $this->setArrayOrder($column_overrides);
   }
 
   /**

--- a/src/Plugin/Visualisation/Style/AxisChart.php
+++ b/src/Plugin/Visualisation/Style/AxisChart.php
@@ -921,23 +921,20 @@ abstract class AxisChart extends TableVisualisationStyleBase {
       'weight',
       'class',
     ];
-    $column_overrides_sorted = [];
-    $pair = 2;
+
+    $column_overrides = array_fill_keys($this->fieldLabelsOriginal(), []);
 
     foreach ($this->config('data', 'column_overrides') as $field_name => $column_override) {
-      $field_overrides = explode(PHP_EOL, $column_override);
-
-      foreach ($field_overrides as $field_override) {
-        $field_override_array = explode('|', trim($field_override), $pair);
-
-        if (count($field_override_array) === $pair && in_array($field_override_array[0], $allowed_overrides)) {
-          $column_overrides_sorted[$field_name][$field_override_array[0]] = $field_override_array[1];
-        }
+      if (empty($column_override)) {
+        continue;
       }
+
+      $real_field_name = substr($field_name, 1);
+      $column_overrides[$real_field_name] = $this->dvfHelpers->configStringToArray($column_override);
     }
 
-    $column_overrides_sorted = array_merge(array_fill_keys($this->fieldLabelsOriginal(), []), $column_overrides_sorted);
-    return $this->setArrayOrder($column_overrides_sorted);
+    $sorted = $this->setArrayOrder($column_overrides);
+    return $sorted;
   }
 
   /**
@@ -955,19 +952,16 @@ abstract class AxisChart extends TableVisualisationStyleBase {
    */
   protected function setArrayOrder(array $array_to_order, $weight_key = 'weight') {
     $i = 0;
+
+    // Set default weights if does not exist.
     foreach ($array_to_order as $key => $value) {
       $array_to_order[$key][$weight_key] = isset($value[$weight_key]) ? (int) $value[$weight_key] : $i;
       $i++;
     }
 
-    $weights = [];
-    foreach ($array_to_order as $key => $row) {
-      $weights[$key] = $row[$weight_key];
-    }
-    array_multisort($weights, SORT_ASC, $array_to_order);
-
+    // Sort by weight and return.
+    uasort($array_to_order, function ($a, $b) use ($weight_key) { return $a[$weight_key] - $b[$weight_key]; });
     return $array_to_order;
-
   }
 
 }

--- a/src/Plugin/Visualisation/Style/BarChart.php
+++ b/src/Plugin/Visualisation/Style/BarChart.php
@@ -123,7 +123,7 @@ class BarChart extends AxisChart {
 
     $settings['chart']['data']['type'] = 'bar';
     $settings['chart']['data']['stacked'] = $this->config('bar_chart', 'stacked');
-    $settings['chart']['data']['groups'] = $this->config('data', 'fields');
+    $settings['chart']['data']['groups'] = $this->fields();
     $settings['chart']['data']['order'] = $this->config('bar_chart', 'data', 'order');
     $settings['bar']['width']['ratio'] = $this->config('bar_chart', 'bar', 'width', 'ratio');
     $settings['bar']['width']['value'] = $this->config('bar_chart', 'bar', 'width', 'value');

--- a/src/Plugin/Visualisation/Style/GaugeChart.php
+++ b/src/Plugin/Visualisation/Style/GaugeChart.php
@@ -101,7 +101,7 @@ class GaugeChart extends AxisChart {
     $settings = parent::chartBuildSettings($records);
 
     $settings['chart']['data']['type'] = 'gauge';
-    $settings['chart']['data']['groups'] = $this->config('data', 'fields');
+    $settings['chart']['data']['groups'] = $this->fields();
     $settings['gauge']['label']['show'] = $this->config('gauge_chart', 'gauge', 'label', 'show');
     $settings['gauge']['label']['percentage'] = $this->config('gauge_chart', 'gauge', 'label', 'percentage');
     $settings['gauge']['units'] = $this->config('gauge_chart', 'gauge', 'units');

--- a/src/Plugin/Visualisation/Style/LineChart.php
+++ b/src/Plugin/Visualisation/Style/LineChart.php
@@ -106,7 +106,7 @@ class LineChart extends AxisChart {
 
     $settings['chart']['data']['type'] = $this->config('line_chart', 'area', 'enabled') ? 'area' : 'line';
     $settings['chart']['data']['stacked'] = $this->config('line_chart', 'stacked');
-    $settings['chart']['data']['groups'] = $this->config('data', 'fields');
+    $settings['chart']['data']['groups'] = $this->fields();
     $settings['point']['show'] = $this->config('line_chart', 'data', 'points', 'show');
 
     return $settings;

--- a/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
+++ b/src/Plugin/Visualisation/Style/VisualisationStyleBase.php
@@ -247,7 +247,7 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       $form['data']['column_overrides'][$override] = [
         '#type' => 'textarea',
         '#rows' => 2,
-        '#title' => $override,
+        '#title' => substr($override, 1),
         '#default_value' => $this->config('data', 'column_overrides', $override),
       ];
     }
@@ -419,7 +419,8 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
       unset($labels['_id']);
     }
 
-    return array_keys($labels);
+    $keys = array_keys($labels);
+    return array_map('strval', $keys);
   }
 
   /**
@@ -497,19 +498,25 @@ abstract class VisualisationStyleBase extends PluginBase implements Visualisatio
    * Returns the column override values to make a form array.
    *
    * @return array
-   *   The array of column override values.
+   *   The array of column override values. NOTE: Each value has a underscore
+   *   prependend to ensure it is a string. Without this the field name gets
+   *   converted to a int/float during form submission.
    */
   protected function getColumnOverrideValues() {
 
     if ($this->config('axis', 'x', 'x_axis_grouping') === 'values' && $this->config('axis', 'x', 'tick', 'values', 'field')) {
       $x_tick_field = $this->config('axis', 'x', 'tick', 'values', 'field');
-      return array_map(function ($e) use ($x_tick_field) {
+      $columns = array_map(function ($e) use ($x_tick_field) {
         return $e->{$x_tick_field};
       }, $this->getVisualisation()->data());
     }
     else {
-      return $this->fieldLabelsOriginal();
+      $columns = $this->fieldLabelsOriginal();
     }
+
+    return array_map(function($item) {
+      return '_' . $item;
+    }, $columns);
   }
 
   /**


### PR DESCRIPTION
Column overrides had a number of bugs, specifically when the field keys were numbers (eg years). This fix ensures column overrides are correctly parsed and applied regardless of key format